### PR TITLE
Fix deployment payload formatting in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,16 @@ jobs:
             exit 1
           fi
 
-          payload=$(cat <<'JSON'
-            {"event_type":"task_updated","client_payload":{"run_id":"${{ github.run_id }}","sha":"${{ github.sha }}","ref":"${{ github.ref }}"}}
-            JSON
+          payload=$(cat <<EOF
+            {
+              "event_type": "task_updated",
+              "client_payload": {
+                "run_id": "${{ github.run_id }}",
+                "sha": "${{ github.sha }}",
+                "ref": "${{ github.ref }}"
+              }
+            }
+          EOF
           )
 
           response_file=$(mktemp)


### PR DESCRIPTION
## Summary
- replace the heredoc used to build the repository dispatch payload with a properly terminated delimiter
- pretty-print the JSON payload so the workflow can trigger the deployment successfully

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dd740215b0832894f17984865143d0