### PR TITLE
fix(tasks): load the selected board, not the one selected at mount

### DIFF
--- a/e2e/board-switch-race.spec.ts
+++ b/e2e/board-switch-race.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Regression test for the board-switch load race.
+ *
+ * Repro (reported in prod): a returning user lands on /task/. Boards paint
+ * immediately from the localStorage cache, but `initialLoad()` is still
+ * fetching the server view in the background. The user clicks a non-default
+ * board during that window. When the fetch lands, the UI is left showing the
+ * *default* board's tasks while the clicked board stays selected.
+ *
+ * Cause: `reload()` sliced the response against the `currentBoardId` captured
+ * in its closure at mount ('main'), not the board the user had since selected.
+ */
+
+const SESSION_ID = 'race-test-session'
+const USER_TYPE = 'friend'
+
+const MAIN_TASK = 'MAIN-BOARD-ONLY-TASK'
+const WORK_TASK = 'WORK-BOARD-ONLY-TASK'
+
+/** How long the background /boards sync is held open, in ms. */
+const SYNC_DELAY_MS = 2500
+
+function boardsPayload() {
+  const now = new Date().toISOString()
+  return {
+    version: 1,
+    updatedAt: now,
+    boards: [
+      {
+        id: 'main',
+        name: 'main',
+        tags: [],
+        tasks: [{ id: 'task-main-1', title: MAIN_TASK, state: 'Active', createdAt: now, tag: null }]
+      },
+      {
+        id: 'work',
+        name: 'work',
+        tags: [],
+        tasks: [{ id: 'task-work-1', title: WORK_TASK, state: 'Active', createdAt: now, tag: null }]
+      }
+    ]
+  }
+}
+
+/**
+ * Seed the localStorage the app would have from a previous visit, so boards
+ * render before the network sync resolves — that gap is the race window.
+ */
+async function seedCachedSession(page: Page) {
+  const payload = boardsPayload()
+  await page.addInitScript(
+    ({ userType, sessionId, data }) => {
+      localStorage.clear()
+      localStorage.setItem('hadoku_user_type', userType)
+      localStorage.setItem('hadoku_session_id', sessionId)
+      localStorage.setItem(
+        `${userType}-${sessionId}-boards`,
+        JSON.stringify({
+          version: 1,
+          updatedAt: data.updatedAt,
+          boards: data.boards.map(b => ({ id: b.id, name: b.name, tags: b.tags }))
+        })
+      )
+      for (const board of data.boards) {
+        localStorage.setItem(
+          `${userType}-${sessionId}-${board.id}-tasks`,
+          JSON.stringify({ version: 1, updatedAt: data.updatedAt, tasks: board.tasks })
+        )
+      }
+    },
+    { userType: USER_TYPE, sessionId: SESSION_ID, data: payload }
+  )
+}
+
+async function stubApi(page: Page) {
+  await page.route('**/task/api/session/handshake', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ userType: USER_TYPE, preferences: null })
+    })
+  )
+
+  // Preferences must resolve for the shell to unblock; contents don't matter here.
+  await page.route('**/prefs/api/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ preferences: {} })
+    })
+  )
+
+  // The board sync — held open long enough to click a board while it's in flight.
+  await page.route('**/task/api/boards**', async route => {
+    await new Promise(resolve => setTimeout(resolve, SYNC_DELAY_MS))
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(boardsPayload())
+    })
+  })
+}
+
+test.describe('Board switch during initial load', () => {
+  test('keeps the clicked board’s tasks when the background sync lands', async ({ page }) => {
+    await seedCachedSession(page)
+    await stubApi(page)
+
+    let boardsResolved = false
+    page.on('response', res => {
+      if (res.url().includes('/task/api/boards')) boardsResolved = true
+    })
+
+    await page.goto('/')
+
+    // Boards paint from cache while the sync is still in flight.
+    const workBoard = page.locator('button.board-btn', { hasText: 'work' })
+    await workBoard.waitFor({ state: 'visible', timeout: 15000 })
+    expect(
+      boardsResolved,
+      'sync should still be in flight — the race window has closed, test is not exercising the bug'
+    ).toBe(false)
+
+    // Switch boards mid-flight.
+    await workBoard.click()
+    await expect(page.locator('.task-app__item-title')).toHaveText(WORK_TASK)
+
+    // Now let the background sync land and overwrite state.
+    await expect.poll(() => boardsResolved, { timeout: 15000 }).toBe(true)
+    await page.waitForTimeout(500) // let the resulting setState flush
+
+    // The clicked board must still be selected AND showing its own tasks.
+    await expect(workBoard).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.locator('.task-app__item-title')).toHaveText(WORK_TASK)
+    await expect(page.locator('.task-app__item-title', { hasText: MAIN_TASK })).toHaveCount(0)
+  })
+})

--- a/src/hooks/useTasks/index.ts
+++ b/src/hooks/useTasks/index.ts
@@ -2,7 +2,7 @@
  * Hook for managing task operations
  */
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { createApi, type SyncErrorReporter } from '../../api/client'
 import type { Task, BoardsFile } from '../../domain/types'
 import { parseTaskInput, splitTags, formatError } from '../../domain/utils/tags'
@@ -29,6 +29,20 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
   const [boards, setBoards] = useState<BoardsFile | null>(null)
   const [currentBoardId, setCurrentBoardId] = useState<string>('main')
 
+  // `reload` runs async and is often kicked off unawaited (mount, BroadcastChannel,
+  // mutations). Reading the selected board from state would capture whatever was
+  // selected when the closure was created, so a board switch during an in-flight
+  // load would render the *previous* board's tasks. The ref always holds the live
+  // selection, so a load that resolves after a switch slices the correct board.
+  const currentBoardIdRef = useRef(currentBoardId)
+  const selectBoard = useCallback((boardId: string) => {
+    currentBoardIdRef.current = boardId
+    setCurrentBoardId(boardId)
+  }, [])
+
+  // Monotonic counter so a slow reload can't clobber the results of a newer one.
+  const reloadSeqRef = useRef(0)
+
   async function initialLoad() {
     logger.info('[useTasks] initialLoad called')
     // ✅ Sync from API first (only on initial load, if not public mode)
@@ -40,13 +54,22 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
   }
 
   async function reload() {
-    logger.info('[useTasks] reload called', {
-      currentBoardId,
-      stack: new Error().stack?.split('\n').slice(1, 4).join('\n')
-    })
+    const seq = ++reloadSeqRef.current
+    logger.info('[useTasks] reload called', { currentBoardId: currentBoardIdRef.current, seq })
+
     const bf = await api.getBoards()
+
+    // A newer reload started while this one was awaiting — its result wins.
+    if (seq !== reloadSeqRef.current) {
+      logger.info('[useTasks] reload superseded, discarding stale result', {
+        seq,
+        latest: reloadSeqRef.current
+      })
+      return
+    }
+
     setBoards(bf)
-    const { tasks: boardTasks } = extractBoardTasks(bf, currentBoardId)
+    const { tasks: boardTasks } = extractBoardTasks(bf, currentBoardIdRef.current)
     setTasks(boardTasks)
   }
 
@@ -59,7 +82,7 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
     setTasks([])
     setPendingOperations(new Set())
     setBoards(null)
-    setCurrentBoardId('main')
+    selectBoard('main')
     void reload()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userType, sessionId])
@@ -295,13 +318,9 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
   // Board helpers
   async function createBoard(boardId: string) {
     await api.createBoard(boardId)
-    // Switch to the new board first, then reload
-    setCurrentBoardId(boardId)
-    // Fetch the boards and set tasks for the new board
-    const bf = await api.getBoards()
-    setBoards(bf)
-    const { tasks: boardTasks } = extractBoardTasks(bf, boardId)
-    setTasks(boardTasks)
+    // Switch first: reload slices against the live selection.
+    selectBoard(boardId)
+    await reload()
   }
 
   // Move multiple tasks to another board
@@ -336,11 +355,8 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
 
       // Switch to the target board and reload it
       logger.info('[useTasks] moveTasksToBoard: switching to target board', { targetBoardId })
-      setCurrentBoardId(targetBoardId)
-      const bf = await api.getBoards()
-      setBoards(bf)
-      const { tasks: boardTasks } = extractBoardTasks(bf, targetBoardId)
-      setTasks(boardTasks)
+      selectBoard(targetBoardId)
+      await reload()
       logger.info('[useTasks] moveTasksToBoard END')
     } catch (error) {
       logger.error('[useTasks] moveTasksToBoard ERROR', {
@@ -352,18 +368,11 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
 
   async function deleteBoard(boardId: string) {
     await api.deleteBoard(boardId)
-    // If we're deleting the current board, switch to main and load its tasks
+    // If we're deleting the current board, fall back to main before reloading.
     if (currentBoardId === boardId) {
-      setCurrentBoardId('main')
-      // Fetch boards and explicitly load main board's tasks
-      const bf = await api.getBoards()
-      setBoards(bf)
-      const { tasks: boardTasks } = extractBoardTasks(bf, 'main')
-      setTasks(boardTasks)
-    } else {
-      // If we're not on the deleted board, just reload normally
-      await reload()
+      selectBoard('main')
     }
+    await reload()
   }
 
   async function createTagOnBoard(tag: string) {
@@ -377,12 +386,13 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
   }
 
   function switchBoard(boardId: string) {
-    setCurrentBoardId(boardId)
+    selectBoard(boardId)
     const { tasks: boardTasks, foundBoard } = extractBoardTasks(boards, boardId)
     if (foundBoard) {
       setTasks(boardTasks)
     } else {
-      // Board not present in memory (race) - reload from API
+      // Board not in memory yet (initial load still in flight) — reload will slice
+      // this board once it lands, and supersede any load already running.
       void reload()
     }
   }


### PR DESCRIPTION
## The bug

Selecting a non-default board while the app is still loading switches the UI to that board but shows **the default board's tasks**.

## Cause

A stale closure, not a fetch race.

`reload()` slices the boards response against the `currentBoardId` captured in its closure. It's kicked off unawaited from mount (`useSessionInitialization.ts:130`), so that captured value is whatever was selected then — `'main'`.

Cached boards paint immediately while the sync is still in flight. Clicking a board in that window applies `setCurrentBoardId('work')`, but when the fetch lands, the mount-era closure re-slices `'main'` and calls `setTasks` with it. Board `work` selected, main's tasks rendered. The sync is slow enough in practice that this window is open on a typical cold load.

## Fix

Slice against a ref holding the **live** selection.

Cancelling the in-flight fetch would be the wrong fix: the boards endpoint is board-agnostic and returns *every* board, so the in-flight response already contains the newly-selected board's data. Nothing needs cancelling — only the slice was wrong. No UI lock, no wasted round-trip.

Also adds a monotonic sequence guard so a slow `reload` can't clobber a newer one's results. That additionally makes the `Promise.race` timeout in `BoardsSection.tsx:62` safe — its losing promise kept running and still called `setTasks`.

Cleanup: `createBoard` / `moveTasksToBoard` / `deleteBoard` each hand-rolled a copy of `reload()` with an explicit board id purely to dodge this stale closure. They collapse back to `selectBoard()` + `reload()`.

## Verification

`e2e/board-switch-race.spec.ts` seeds a cached boards index (returning-visitor state), holds the boards fetch open 2.5s, and clicks a non-default board mid-flight.

Reverting the fix makes it fail with exactly the reported symptom — right board selected, wrong data:

```
Expected: "WORK-BOARD-ONLY-TASK"
Received: "MAIN-BOARD-ONLY-TASK"
```

Full suite: 37 passed, 0 failed.