### PR TITLE
fix(ci): stop auto-update clobbering the tracked .npmrc

### DIFF
--- a/.github/workflows/update-wolffm.yml
+++ b/.github/workflows/update-wolffm.yml
@@ -33,10 +33,15 @@ jobs:
           node-version: '22'
           cache: pnpm
 
-      - name: Configure .npmrc for GitHub Packages
+      # Auth goes in ~/.npmrc, NOT the repo's tracked .npmrc (which carries the
+      # registry line and nothing else). Writing the token into the tracked file
+      # leaves the tree permanently dirty, which defeats the no-op check below —
+      # and puts a secret one stray `git add .` away from being committed.
+      # Mirrors publish.yml.
+      - name: Configure npm auth for GitHub Packages
         run: |
-          echo "@wolffm:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.HADOKU_SITE_TOKEN }}" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.HADOKU_SITE_TOKEN }}" > ~/.npmrc
+          echo "@wolffm:registry=https://npm.pkg.github.com" >> ~/.npmrc
 
       - name: Update @wolffm/* to latest
         env:
@@ -52,12 +57,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if [ -z "$(git status --porcelain)" ]; then
+          # Scope the no-op check to exactly the files we commit. A repo-wide
+          # `git status` check would let any unrelated dirt fall through to an
+          # empty `git commit`, which exits non-zero and fails the run.
+          FILES="package.json pnpm-lock.yaml themes/package.json task-ui-components/package.json"
+
+          if [ -z "$(git status --porcelain -- $FILES)" ]; then
             echo "✅ No @wolffm package updates available"
             exit 0
           fi
 
-          git add package.json pnpm-lock.yaml themes/package.json task-ui-components/package.json
+          git add $FILES
           git commit -m "chore: auto-update @wolffm/* to latest"
 
           for i in 1 2 3; do


### PR DESCRIPTION
## The failure

`Auto-update @wolffm packages` has been failing on `main` on essentially every dispatch that finds no new packages — 6+ red runs today alone.

## Cause

`.npmrc` is **tracked**, and holds the registry line and nothing else:

```
@wolffm:registry=https://npm.pkg.github.com
```

The workflow overwrote it with registry + auth token:

```yaml
echo "@wolffm:registry=..." > .npmrc          # clobbers the tracked file
echo "//npm.pkg.github.com/:_authToken=..." >> .npmrc
```

Which cascades:

1. The working tree is now **permanently dirty**, so the `git status --porcelain` "no updates available" early-exit can never fire.
2. `git add` stages only `package.json` / `pnpm-lock.yaml` / the two subpackage manifests — not `.npmrc`.
3. So when no `@wolffm` updates actually exist, **nothing is staged**, `git commit` exits non-zero on the empty commit, and `shell: bash -e` fails the run.

Every no-op dispatch was a red build. It only went green when there happened to be a real update.

It also put a secret in a tracked file — one stray `git add .` from committing the token.

## Fix

Write auth to `~/.npmrc` and leave the tracked `.npmrc` alone. This is what `publish.yml:41` already does; the two workflows had simply drifted.

Also scope the no-op check to exactly the files the step commits, so unrelated dirt can't fall through to an empty commit again.

## Verification

Replayed both paths of the step's shell logic against a real clone.

**Old logic, no updates available** — reproduces the CI failure, with the same git output as the real failed run:

```
early-exit did NOT fire. git status sees:  M .npmrc
  no changes added to commit
>>> git commit FAILED (nothing staged) -> bash -e -> EXIT 1   ❌ RED BUILD
token leaked into tracked file? YES
```

**New logic, no updates available:**

```
early-exit fired -> exit 0   ✅ GREEN
repo .npmrc still clean? YES - token only in ~/.npmrc
```

**New logic, updates genuinely exist** — still commits:

```
✅ committed: chore: auto-update @wolffm/* to latest
```