### PR TITLE
Gate external dependencies behind a 7-day cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,12 +6,13 @@ packages:
 allowBuilds:
   esbuild: true
 
-# No package-age gate. pnpm 11 defaults a ~24h minimum-release-age supply-chain
-# delay; we disable it so package updates (incl. @wolffm/* auto-sync) aren't held back.
-minimumReleaseAge: 0
-
-onlyBuiltDependencies:
-  - esbuild
-
 overrides:
   js-yaml: 4.1.1
+
+# Supply-chain: external packages must be 7 days old before they resolve. Malicious npm
+# releases are near-always caught within hours (Shai-Hulud ~12h, debug/chalk ~2.5h), so we
+# let the ecosystem find them first. @wolffm/* is EXEMPT (verified): it is the cross-ecosystem
+# deploy path and must install immediately — gating it would stall the whole package sync.
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@wolffm/*'


### PR DESCRIPTION
Re-opening: the previous PR was auto-closed when an early push briefly left the branch identical to main.

Brings this repo in line with the rest of the ecosystem (13 repos already merged).

```yaml
minimumReleaseAge: 10080        # 7 days — external packages
minimumReleaseAgeExclude:
  - '@wolffm/*'                 # deploy path — installs immediately
```

Most npm supply-chain attacks are caught within hours (Shai-Hulud ~12h, debug/chalk ~2.5h), so refusing brand-new versions lets the ecosystem find the bad ones first. `@wolffm/*` is exempt — **verified**: a @wolffm package published hours earlier still resolves to newest through the gate, while a 5-day-old external package is correctly blocked. (npm cannot express this exemption at all — hence pnpm everywhere.)

Lockfile is already policy-clean, so no dependency changes. Also drops `onlyBuiltDependencies`, which pnpm 11 removed in favour of `allowBuilds`.