### PR TITLE
fix(lint): type the phase0-verify response body instead of any

### DIFF
--- a/worker/test/phase0-verify.ts
+++ b/worker/test/phase0-verify.ts
@@ -55,6 +55,14 @@ function headers(extra: Record<string, string> = {}) {
   }
 }
 
+/** The response fields these checks actually read. */
+interface ResponseBody {
+  version?: number
+  currentVersion?: number
+  code?: string
+  tasks?: unknown[]
+}
+
 async function req(
   method: string,
   path: string,
@@ -69,7 +77,7 @@ async function req(
     },
     env
   )
-  let json: any = null
+  let json: ResponseBody | null = null
   try {
     json = await res.clone().json()
   } catch {


### PR DESCRIPTION
Clears the repo's last eslint warning (`@typescript-eslint/no-explicit-any` in `worker/test/phase0-verify.ts:72`).

The checks only ever read `version` / `currentVersion` / `code` / `tasks`, so the body gets that shape rather than `any`.

`pnpm run lint` now reports **0 problems**; `tsc --noEmit` clean.