### PR TITLE
fix(theme): honor host-inherited theme; migrate legacy simpleMode; repair broken e2e specs

### DIFF
--- a/e2e/prod-cold-load.spec.ts
+++ b/e2e/prod-cold-load.spec.ts
@@ -173,7 +173,9 @@ test.describe('Production cold-load performance', () => {
   })
 
   test.afterAll(async () => {
-    await browser.close()
+    // browser is undefined when the suite is skipped (RUN_PROD_PERF unset) —
+    // afterAll still runs and an unguarded close() fails the skipped suite.
+    await browser?.close()
   })
 
   test(`cold load: skeleton < ${SKELETON_BUDGET_MS}ms, app < ${APP_BUDGET_MS}ms (median of ${RUNS})`, async () => {

--- a/e2e/theme-inheritance.spec.ts
+++ b/e2e/theme-inheritance.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * E2E tests for the hadoku.me theme-integration contract.
+ *
+ * The host page persists the current theme in sessionStorage['hadoku-theme']
+ * and pushes changes into the embedded app by setting data-theme and
+ * dispatching a synthetic StorageEvent for that key. Verifies that:
+ *
+ * 1. A fully-qualified inherited theme (e.g. 'ocean-dark') is adopted on load
+ *    and NOT clobbered back to the app default (the old prefs-client
+ *    write-through bug)
+ * 2. A bare family token (e.g. 'coffee') expands to the light/dark variant
+ *    per prefers-color-scheme instead of falling through to 'light'
+ * 3. A StorageEvent push-down after load is adopted (with the same
+ *    normalization)
+ * 4. Only an explicit in-app theme change writes sessionStorage['hadoku-theme']
+ */
+
+const THEME_KEY = 'hadoku-theme'
+
+async function setupRoutes(page: Page) {
+  await page.route('**/task/api/session/handshake', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ preferences: null })
+    })
+  })
+
+  await page.route('**/task/api/boards*', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        boards: [{ id: 'main', name: 'Main', tasks: [], tags: [] }]
+      })
+    })
+  })
+}
+
+async function seedHostTheme(page: Page, theme: string) {
+  await page.addInitScript(({ key, value }) => window.sessionStorage.setItem(key, value), {
+    key: THEME_KEY,
+    value: theme
+  })
+}
+
+async function loadApp(page: Page) {
+  await page.goto('/')
+  await page.waitForSelector('h1.task-app__header', { timeout: 15000 })
+}
+
+function getAppliedTheme(page: Page): Promise<string | null> {
+  return page.evaluate(() => document.documentElement.getAttribute('data-theme'))
+}
+
+test.describe('Theme inheritance from host page', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupRoutes(page)
+  })
+
+  test('adopts a fully-qualified inherited theme and does not clobber it', async ({ page }) => {
+    await seedHostTheme(page, 'ocean-dark')
+    await loadApp(page)
+
+    await expect.poll(() => getAppliedTheme(page)).toBe('ocean-dark')
+
+    // The shared key must survive hydration untouched — the app only writes
+    // it on an explicit in-app theme change.
+    await page.waitForTimeout(500)
+    expect(await page.evaluate(key => window.sessionStorage.getItem(key), THEME_KEY)).toBe(
+      'ocean-dark'
+    )
+    expect(await getAppliedTheme(page)).toBe('ocean-dark')
+  })
+
+  test('expands a bare family token per light color scheme', async ({ page }) => {
+    // Playwright contexts default to prefers-color-scheme: light
+    await seedHostTheme(page, 'coffee')
+    await loadApp(page)
+
+    await expect.poll(() => getAppliedTheme(page)).toBe('coffee-light')
+  })
+
+  test('expands a bare family token per dark color scheme', async ({ browser }) => {
+    const context = await browser.newContext({ colorScheme: 'dark' })
+    const page = await context.newPage()
+    await setupRoutes(page)
+    await seedHostTheme(page, 'coffee')
+    await loadApp(page)
+
+    await expect.poll(() => getAppliedTheme(page)).toBe('coffee-dark')
+
+    await context.close()
+  })
+
+  test('adopts a theme pushed down via StorageEvent after load', async ({ page }) => {
+    await loadApp(page)
+
+    await page.evaluate(key => {
+      window.dispatchEvent(new StorageEvent('storage', { key, newValue: 'strawberry-dark' }))
+    }, THEME_KEY)
+    await expect.poll(() => getAppliedTheme(page)).toBe('strawberry-dark')
+
+    // Push-down also normalizes bare family tokens (light scheme by default).
+    await page.evaluate(key => {
+      window.dispatchEvent(new StorageEvent('storage', { key, newValue: 'lavender' }))
+    }, THEME_KEY)
+    await expect.poll(() => getAppliedTheme(page)).toBe('lavender-light')
+  })
+
+  test('explicit in-app theme change writes the shared sessionStorage key', async ({ page }) => {
+    await loadApp(page)
+
+    await page.locator('.theme-toggle-btn').click()
+    await expect(page.locator('.theme-picker__dropdown')).toBeVisible()
+    await page.locator('.theme-pill__btn:not(.active)').first().click()
+
+    const applied = await getAppliedTheme(page)
+    expect(applied).not.toBeNull()
+    await expect
+      .poll(() => page.evaluate(key => window.sessionStorage.getItem(key), THEME_KEY))
+      .toBe(applied)
+  })
+})

--- a/e2e/theme-mode.spec.ts
+++ b/e2e/theme-mode.spec.ts
@@ -9,14 +9,26 @@ import { test, expect, type Page } from '@playwright/test'
  *   3. The Simple/Advanced toggle is visible only when the active theme has
  *      an advanced visual contract (light, cyberpunk-dark) and hidden
  *      otherwise (e.g. coffee-light)
- *   4. Clicking the toggle flips data-theme-mode and persists across reload
- *   5. Legacy `simpleMode: true` saved preferences are migrated to
- *      `themeMode: 'simple'` on first load and the legacy key is dropped
+ *   4. Clicking the toggle flips data-theme-mode and persists to the
+ *      prefs-client cache (unified prefs store)
+ *   5. Legacy `simpleMode` saved preferences are migrated to `themeMode`
+ *      on first load and the legacy localStorage key is dropped
  */
 
 const PUBLIC_USER_TYPE = 'public'
 const PUBLIC_SESSION_ID = 'public-test-session'
 const PREFS_KEY = `${PUBLIC_USER_TYPE}-${PUBLIC_SESSION_ID}-preferences`
+// @wolffm/prefs-client optimistic cache: `prefs-cache:{userId}:{appId}`.
+// The mocked whoami below resolves the anon user, so the key is stable.
+const SDK_CACHE_KEY = 'prefs-cache:anon:task'
+
+/** Read the prefs-client cache envelope's blob from localStorage. */
+function readSdkCacheBlob(page: Page): Promise<Record<string, unknown> | null> {
+  return page.evaluate(key => {
+    const raw = window.localStorage.getItem(key)
+    return raw ? (JSON.parse(raw).blob as Record<string, unknown>) : null
+  }, SDK_CACHE_KEY)
+}
 
 async function setupRoutes(page: Page) {
   await page.route('**/task/api/session/handshake', async route => {
@@ -37,6 +49,54 @@ async function setupRoutes(page: Page) {
         boards: [{ id: 'main', name: 'Main', tasks: [], tags: [] }]
       })
     })
+  })
+
+  // Hermetic prefs backend for the @wolffm/prefs-client SDK — without it the
+  // tests depend on real hadoku.me network behavior (a successful GET after a
+  // debounced PUT would clobber the optimistic cache with live server state).
+  // The endpoints are cross-origin from the vite dev server, so every fulfill
+  // needs CORS headers and the PUT preflight must be answered.
+  const corsHeaders = (origin: string) => ({
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, X-User-Key, X-Device-Id',
+    'Access-Control-Allow-Methods': 'GET, PUT, OPTIONS'
+  })
+
+  await page.route('**/session/whoami', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: corsHeaders(route.request().headers()['origin'] ?? '*'),
+      body: JSON.stringify({ userId: 'anon', userType: 'public' })
+    })
+  })
+
+  // PUTs are accepted (writes flush cleanly); GETs return 404 so the SDK's
+  // background refresh keeps the optimistic localStorage cache authoritative.
+  // A 200 GET would clobber not-yet-flushed patches from the other save scope
+  // (the SDK overwrites its optimistic state with the server's merged blob
+  // while patches are still debounce-pending) — asserting on the optimistic
+  // cache matches what the app actually renders from.
+  const versions = { user: 0, device: 0 }
+  await page.route('**/prefs/api/v1/task', async route => {
+    const request = route.request()
+    const headers = corsHeaders(request.headers()['origin'] ?? '*')
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers })
+      return
+    }
+    if (request.method() === 'PUT') {
+      const { scope } = request.postDataJSON() as { scope: 'user' | 'device' }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({ scope, version: ++versions[scope] })
+      })
+      return
+    }
+    await route.fulfill({ status: 404, headers })
   })
 }
 
@@ -188,7 +248,9 @@ test.describe('Theme Mode', () => {
     await expect(page.locator('.theme-picker__mode-btn').nth(0)).toHaveClass(/active/)
   })
 
-  test('clicking Advanced flips data-theme-mode and persists to localStorage', async ({ page }) => {
+  test('clicking Advanced flips data-theme-mode and persists to the prefs cache', async ({
+    page
+  }) => {
     await seedPublicSession(page, {
       version: 1,
       updatedAt: new Date().toISOString(),
@@ -209,14 +271,10 @@ test.describe('Theme Mode', () => {
       .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-theme-mode')))
       .toBe('advanced')
 
-    // Persistence: the public-user prefs key in localStorage should now have themeMode='advanced'
+    // Persistence: the prefs-client cache (unified store) should now have
+    // themeMode='advanced' — the legacy PREFS_KEY blob is gone post-migration.
     await expect
-      .poll(() =>
-        page.evaluate(key => {
-          const raw = window.localStorage.getItem(key)
-          return raw ? (JSON.parse(raw).themeMode as string) : null
-        }, PREFS_KEY)
-      )
+      .poll(async () => (await readSdkCacheBlob(page))?.themeMode ?? null)
       .toBe('advanced')
   })
 
@@ -236,14 +294,17 @@ test.describe('Theme Mode', () => {
       .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-theme-mode')))
       .toBe('simple')
 
-    const stored = await page.evaluate(key => {
-      const raw = window.localStorage.getItem(key)
-      return raw ? JSON.parse(raw) : null
-    }, PREFS_KEY)
+    // Migration outcome: the legacy localStorage blob is removed and the
+    // unified store's cache carries themeMode with the simpleMode key dropped.
+    await expect
+      .poll(() => page.evaluate(key => window.localStorage.getItem(key), PREFS_KEY))
+      .toBeNull()
 
-    expect(stored).not.toBeNull()
-    expect(stored.themeMode).toBe('simple')
-    expect('simpleMode' in stored).toBe(false)
+    // Poll past the SDK's 1s save debounce + post-flush refresh.
+    await expect
+      .poll(async () => (await readSdkCacheBlob(page))?.themeMode ?? null, { timeout: 10000 })
+      .toBe('simple')
+    expect('simpleMode' in ((await readSdkCacheBlob(page)) ?? {})).toBe(false)
   })
 
   test('legacy simpleMode=false migrates to themeMode=advanced', async ({ page }) => {
@@ -261,12 +322,13 @@ test.describe('Theme Mode', () => {
       .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-theme-mode')))
       .toBe('advanced')
 
-    const stored = await page.evaluate(key => {
-      const raw = window.localStorage.getItem(key)
-      return raw ? JSON.parse(raw) : null
-    }, PREFS_KEY)
+    await expect
+      .poll(() => page.evaluate(key => window.localStorage.getItem(key), PREFS_KEY))
+      .toBeNull()
 
-    expect(stored.themeMode).toBe('advanced')
-    expect('simpleMode' in stored).toBe(false)
+    await expect
+      .poll(async () => (await readSdkCacheBlob(page))?.themeMode ?? null, { timeout: 10000 })
+      .toBe('advanced')
+    expect('simpleMode' in ((await readSdkCacheBlob(page)) ?? {})).toBe(false)
   })
 })

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -9,6 +9,7 @@ import type { ThemeName } from '../app/types'
 import { getThemeFamilies, isExperimentalTheme, type ThemeFamily } from '../app/themeConfig'
 import { logger } from '@wolffm/logger/client'
 import { setTheme as applyThemeToDOM, setThemeMode as applyThemeModeToDOM } from '@wolffm/themes'
+import { THEME_STORAGE_KEY, normalizeThemeName, writeStoredTheme } from '../utils/theme'
 
 export interface UseThemeReturn {
   theme: ThemeName
@@ -131,7 +132,8 @@ export function useTheme(
     preferencesLoaded
   ])
 
-  const setTheme = useCallback(
+  // Shared apply path: optimistic state + DOM + persisted preference.
+  const applyTheme = useCallback(
     (newTheme: ThemeName) => {
       setPendingTheme(newTheme)
       applyThemeToDOM(newTheme)
@@ -139,6 +141,38 @@ export function useTheme(
     },
     [savePreferences]
   )
+
+  // Explicit in-app theme change: additionally publish to the shared
+  // sessionStorage key ('hadoku-theme') so the FOUC script and the hadoku.me
+  // host page see the user's choice. This is the ONLY place the app writes
+  // that key — inherited host themes must never be clobbered on load.
+  const setTheme = useCallback(
+    (newTheme: ThemeName) => {
+      writeStoredTheme(newTheme)
+      applyTheme(newTheme)
+    },
+    [applyTheme]
+  )
+
+  // Theme pushed down from the hadoku.me host page: it sets our data-theme
+  // attribute and dispatches a synthetic StorageEvent for 'hadoku-theme'.
+  // Normalize (bare family tokens like 'coffee' expand per color scheme) and
+  // adopt it through the same state mechanism as setTheme — without writing
+  // sessionStorage back, since the host owns that value here.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== THEME_STORAGE_KEY) return
+      const prefersDark =
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      const incoming = normalizeThemeName(e.newValue, prefersDark)
+      if (!incoming || incoming === theme) return
+      logger.info(`[useTheme] Adopting theme pushed from host page: ${incoming}`)
+      applyTheme(incoming)
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [theme, applyTheme])
 
   // Apply theme to both document root and container (for microfrontend compatibility)
   useEffect(() => {

--- a/src/prefs/taskPrefs.ts
+++ b/src/prefs/taskPrefs.ts
@@ -94,11 +94,21 @@ function getClient(): PrefsClient<TaskPrefs> {
         return blob
       }
     ]
-    // NOTE: no bootstrapToSessionStorage here. sessionStorage['hadoku-theme']
-    // is a shared contract with the hadoku.me host page (and the inline <head>
-    // FOUC script): the host seeds it, and useTheme writes it only on explicit
-    // in-app theme changes. A read-path write-through would clobber an
-    // inherited theme with the app's own resolved default on every hydrate.
+    // NOTE: no bootstrapToSessionStorage here — still required as of
+    // @wolffm/prefs-client@1.0.2 (see package.json), which write-throughs the
+    // resolved blob to sessionStorage on every read/hydrate/refresh/broadcast.
+    // sessionStorage['hadoku-theme'] is a shared contract with the hadoku.me
+    // host page (and the inline <head> FOUC script): the host seeds it, and
+    // useTheme writes it only on explicit in-app theme changes (see
+    // writeStoredTheme in ../utils/theme.ts). A read-path write-through would
+    // clobber an inherited theme with the app's own resolved default.
+    //
+    // A prefs-client fix (mirrors only on explicit save() by default, with a
+    // mirrorBootstrapOnRead opt-in for the old behavior) is prepared on
+    // hadoku_site's fix/prefs-client-race branch but not yet published. Once
+    // this app depends on a version that includes it, bootstrapToSessionStorage
+    // + the manual writeStoredTheme path can likely be consolidated — verify
+    // against e2e/theme-inheritance.spec.ts before removing either side.
   })
   return cachedClient
 }

--- a/src/prefs/taskPrefs.ts
+++ b/src/prefs/taskPrefs.ts
@@ -23,6 +23,7 @@ import { z } from 'zod'
 import { createPrefsClient, type PrefsClient } from '@wolffm/prefs-client'
 import type { UserPreferences } from '../domain/types'
 import { logger } from '@wolffm/logger/client'
+import { readStoredTheme } from '../utils/theme'
 
 // Zod schema mirroring the FLAT UserPreferences shape (src/domain/types.ts).
 // version + updatedAt are NOT persisted as prefs fields — the SDK manages
@@ -57,7 +58,10 @@ function getDefaultTheme(): string {
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-color-scheme: dark)').matches
-  return prefersDark ? 'dark' : 'light'
+  // A theme inherited from the hadoku.me host page (sessionStorage
+  // 'hadoku-theme', bare family tokens expanded per color scheme) beats the
+  // plain system-preference default.
+  return readStoredTheme(prefersDark) ?? (prefersDark ? 'dark' : 'light')
 }
 
 let cachedClient: PrefsClient<TaskPrefs> | null = null
@@ -89,11 +93,12 @@ function getClient(): PrefsClient<TaskPrefs> {
         }
         return blob
       }
-    ],
-    // Keep the inline <head> FOUC script working: it reads
-    // sessionStorage['hadoku-theme'] and applies it as data-theme before
-    // React mounts. The SDK write-throughs the resolved theme on every read.
-    bootstrapToSessionStorage: { theme: 'hadoku-theme' }
+    ]
+    // NOTE: no bootstrapToSessionStorage here. sessionStorage['hadoku-theme']
+    // is a shared contract with the hadoku.me host page (and the inline <head>
+    // FOUC script): the host seeds it, and useTheme writes it only on explicit
+    // in-app theme changes. A read-path write-through would clobber an
+    // inherited theme with the app's own resolved default on every hydrate.
   })
   return cachedClient
 }

--- a/src/prefs/taskPrefs.ts
+++ b/src/prefs/taskPrefs.ts
@@ -208,10 +208,16 @@ async function migrateOnce(userType: string, sessionId: string): Promise<void> {
   try {
     const legacy = await readLegacyPrefs(userType, sessionId)
     if (legacy) {
-      await saveSplit(legacy)
+      // Map legacy simpleMode → themeMode here: saveSplit only forwards
+      // known scope fields, so the SDK-level migration never sees simpleMode.
+      const { simpleMode, ...rest } = legacy as UserPreferences & { simpleMode?: boolean }
+      if (simpleMode !== undefined && rest.themeMode === undefined) {
+        rest.themeMode = simpleMode ? 'simple' : 'advanced'
+      }
+      await saveSplit(rest)
       logger.info('[taskPrefs] Migrated legacy prefs into unified store', {
         userType,
-        fields: Object.keys(legacy)
+        fields: Object.keys(rest)
       })
     }
   } catch (err) {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared theme-name utilities for the hadoku.me theme contract.
+ *
+ * The host page persists the current theme in sessionStorage under
+ * 'hadoku-theme' and applies it as data-theme on <html>. The stored value is
+ * either a fully-qualified theme name ('light', 'dark', '<family>-light',
+ * '<family>-dark') or a bare family token (e.g. 'coffee') that must be
+ * expanded to a variant using the system color-scheme preference.
+ */
+
+import { THEME_FAMILIES } from '@wolffm/themes'
+import type { ThemeName } from '../app/types'
+
+/** sessionStorage key shared with the hadoku.me host page + FOUC head script. */
+export const THEME_STORAGE_KEY = 'hadoku-theme'
+
+const VALID_THEMES = new Set<string>(THEME_FAMILIES.flatMap(f => [f.lightTheme, f.darkTheme]))
+
+// Family token → variant pair, e.g. 'coffee' → { light: 'coffee-light',
+// dark: 'coffee-dark' }. The base family maps 'light'/'dark' to themselves,
+// but those are already fully-qualified and matched by VALID_THEMES first.
+const FAMILY_VARIANTS = new Map<string, { light: string; dark: string }>(
+  THEME_FAMILIES.map(f => [
+    f.lightTheme.replace(/-light$/, ''),
+    { light: f.lightTheme, dark: f.darkTheme }
+  ])
+)
+
+/**
+ * Normalize a raw theme value (from sessionStorage or a storage event) to a
+ * fully-qualified ThemeName. Bare family tokens expand to the light/dark
+ * variant per `prefersDark`. Returns null for unrecognized values so callers
+ * can fall back to their own default instead of silently landing on 'light'.
+ */
+export function normalizeThemeName(
+  value: string | null | undefined,
+  prefersDark: boolean
+): ThemeName | null {
+  const raw = value?.trim()
+  if (!raw) return null
+  if (VALID_THEMES.has(raw)) return raw as ThemeName
+  const variants = FAMILY_VARIANTS.get(raw)
+  if (variants) return (prefersDark ? variants.dark : variants.light) as ThemeName
+  return null
+}
+
+/** Read + normalize the shared theme key. Safe when storage is unavailable. */
+export function readStoredTheme(prefersDark: boolean): ThemeName | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return normalizeThemeName(window.sessionStorage.getItem(THEME_STORAGE_KEY), prefersDark)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist the theme to the shared key. Called ONLY on explicit in-app theme
+ * changes — never as a read/hydrate write-through, so a theme inherited from
+ * the host page is never clobbered by the app's own default.
+ */
+export function writeStoredTheme(theme: ThemeName): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(THEME_STORAGE_KEY, theme)
+  } catch {
+    // Storage unavailable (e.g. blocked third-party context) — non-fatal.
+  }
+}


### PR DESCRIPTION
Three related fixes, plus the e2e specs that were failing on `main`.

## Fixes

- **`fix(theme)`** — honor a host-inherited `hadoku-theme` instead of clobbering it.
- **`fix(prefs)`** — migrate the legacy `simpleMode` boolean to `themeMode`.
- **`docs(prefs)`** — note the version-gate and upstream fix behind the sessionStorage workaround.

## Repairs 4 tests that were red on main

`main` currently has four failing e2e tests. All four are fixed here:

- `theme-mode.spec.ts` ×3 — the legacy `simpleMode` → `themeMode` migration these assert didn't exist yet.
- `prod-cold-load.spec.ts` — not a perf failure. `browser` is undefined when the suite is skipped (`RUN_PROD_PERF` unset), but `afterAll` still runs, so the unguarded `browser.close()` threw `TypeError: Cannot read properties of undefined`. Now `browser?.close()`.

## Verification

On this branch, rebased onto current main:

- `pnpm run lint` — **0 problems**
- `tsc --noEmit` — clean
- `pnpm exec playwright test` — **37 passed, 0 failed**, 1 skipped (the prod-perf suite, which correctly skips without `RUN_PROD_PERF`)