### PR TITLE
perf(load): stop serialising handshake → prefs → boards

### DIFF
--- a/e2e/cold-load-serialization.spec.ts
+++ b/e2e/cold-load-serialization.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Cold-load critical-path regression test.
+ *
+ * The session init used to run handshake -> prefs -> boards strictly in series,
+ * so first paint was gated on the two slowest network calls and the board sync
+ * didn't even *start* until both had landed. Nothing in prefs or the board sync
+ * actually depends on the handshake: for an authenticated user the sessionId is
+ * known before it runs.
+ *
+ * This pins that they run concurrently. The stubbed latencies below are the
+ * medians measured against prod (hadoku.me), so the shape is realistic.
+ *
+ * Measured A/B with these latencies:
+ *   serial (old):   app mounted +1498ms, server data on screen +1502ms
+ *   parallel (new): app mounted  +446ms, server data on screen  +506ms
+ */
+
+const HANDSHAKE_MS = 575 // prod median
+const PREFS_MS = 170 // prod median
+const BOARDS_MS = 400 // prod median
+
+const SESSION_ID = 'perf-test-session'
+const USER_TYPE = 'friend'
+const TASK_TITLE = 'SERVER-TASK'
+
+function boardsPayload() {
+  const now = new Date().toISOString()
+  return {
+    version: 1,
+    updatedAt: now,
+    boards: [
+      {
+        id: 'main',
+        name: 'main',
+        tags: [],
+        tasks: [{ id: 'srv-1', title: TASK_TITLE, state: 'Active', createdAt: now, tag: null }]
+      }
+    ]
+  }
+}
+
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+/** Ordered log of observable events, so assertions are about causality, not wall-clock. */
+type Marks = {
+  handshakeSent?: number
+  handshakeDelivered?: number
+  prefsSent?: number
+  boardsSent?: number
+  appMounted?: number
+  dataOnScreen?: number
+}
+
+async function stubApiWithProdLatency(page: Page, marks: Marks, t0: () => number) {
+  await page.route('**/task/api/session/handshake', async route => {
+    marks.handshakeSent ??= t0()
+    await delay(HANDSHAKE_MS)
+    marks.handshakeDelivered ??= t0()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ userType: USER_TYPE, preferences: null })
+    })
+  })
+
+  await page.route('**/prefs/api/**', async route => {
+    marks.prefsSent ??= t0()
+    await delay(PREFS_MS)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ preferences: {} })
+    })
+  })
+
+  await page.route('**/task/api/boards**', async route => {
+    marks.boardsSent ??= t0()
+    await delay(BOARDS_MS)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(boardsPayload())
+    })
+  })
+}
+
+test.describe('Cold-load critical path', () => {
+  test('handshake, prefs and board sync run concurrently — not chained', async ({ page }) => {
+    await page.addInitScript(
+      ({ userType, sessionId }) => {
+        localStorage.clear()
+        localStorage.setItem('hadoku_user_type', userType)
+        localStorage.setItem('hadoku_session_id', sessionId)
+      },
+      { userType: USER_TYPE, sessionId: SESSION_ID }
+    )
+    const start = Date.now()
+    const t0 = () => Date.now() - start
+    const marks: Marks = {}
+    await stubApiWithProdLatency(page, marks, t0)
+
+    await page.goto('/')
+
+    await page.locator('.task-app-container').waitFor({ state: 'attached', timeout: 20000 })
+    marks.appMounted = t0()
+
+    await page
+      .locator('.task-app__item-title', { hasText: TASK_TITLE })
+      .waitFor({ state: 'attached', timeout: 20000 })
+    marks.dataOnScreen = t0()
+
+    const { handshakeSent, handshakeDelivered, prefsSent, boardsSent } = marks
+    if (
+      handshakeSent == null ||
+      handshakeDelivered == null ||
+      prefsSent == null ||
+      boardsSent == null
+    ) {
+      throw new Error(
+        `expected handshake, prefs and boards to all fire — got ${JSON.stringify(marks)}`
+      )
+    }
+
+    const rel = (v: number) => `+${v - handshakeSent}ms`
+    console.log(
+      `[cold-load] boot=${handshakeSent}ms | sent: handshake=${rel(handshakeSent)} ` +
+        `prefs=${rel(prefsSent)} boards=${rel(boardsSent)}`
+    )
+    console.log(
+      `[cold-load] app mounted=${rel(marks.appMounted ?? 0)} ` +
+        `data on screen=${rel(marks.dataOnScreen ?? 0)} ` +
+        `| handshake response delivered=${rel(handshakeDelivered)}`
+    )
+
+    // Assert on request ORDERING only — pure causality, immune to how loaded the
+    // machine is. If the chain re-serialises, both of these get issued only after
+    // the handshake response arrives, and both assertions fail.
+    //
+    // Deliberately NOT asserting on mount/paint times: those also depend on React
+    // render speed, so under a loaded parallel suite they cross the handshake
+    // deadline for reasons that have nothing to do with this fix. That's a latency
+    // budget, not an invariant, and it goes flaky. The numbers are logged above.
+    expect(
+      boardsSent,
+      'board sync must be issued while the handshake is still in flight, not after it returns'
+    ).toBeLessThan(handshakeDelivered)
+
+    expect(
+      prefsSent,
+      'prefs must be issued while the handshake is still in flight, not after it returns'
+    ).toBeLessThan(handshakeDelivered)
+  })
+})

--- a/e2e/cold-load-serialization.spec.ts
+++ b/e2e/cold-load-serialization.spec.ts
@@ -111,6 +111,16 @@ test.describe('Cold-load critical path', () => {
       .waitFor({ state: 'attached', timeout: 20000 })
     marks.dataOnScreen = t0()
 
+    // The whole point of the fix is that data lands BEFORE the handshake comes
+    // back — so by now the handshake response usually hasn't been delivered yet.
+    // Wait for it, since it's the baseline every assertion below compares against.
+    await expect
+      .poll(() => marks.handshakeDelivered ?? null, {
+        timeout: 20000,
+        message: 'handshake response should eventually be delivered'
+      })
+      .not.toBeNull()
+
     const { handshakeSent, handshakeDelivered, prefsSent, boardsSent } = marks
     if (
       handshakeSent == null ||

--- a/e2e/session-resilience.spec.ts
+++ b/e2e/session-resilience.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Guards the two behaviours that moved when the cold-load chain was
+ * de-serialised (handshake no longer blocks first paint):
+ *
+ *  1. Session expiry — the handshake result is now handled after the app has
+ *     painted rather than before. The expiry prompt + reload must still happen.
+ *  2. Handshake failure — the app must still become usable. It renders from the
+ *     localStorage cache and the board sync authenticates off the session cookie,
+ *     so a dead handshake must not strand the user on the skeleton.
+ */
+
+const SESSION_ID = 'resilience-session'
+const TASK_TITLE = 'CACHED-TASK'
+
+function boardsPayload() {
+  const now = new Date().toISOString()
+  return {
+    version: 1,
+    updatedAt: now,
+    boards: [
+      {
+        id: 'main',
+        name: 'main',
+        tags: [],
+        tasks: [{ id: 't1', title: TASK_TITLE, state: 'Active', createdAt: now, tag: null }]
+      }
+    ]
+  }
+}
+
+async function seedFriendSession(page: Page) {
+  await page.addInitScript(sessionId => {
+    localStorage.clear()
+    localStorage.setItem('hadoku_user_type', 'friend')
+    localStorage.setItem('hadoku_session_id', sessionId)
+  }, SESSION_ID)
+}
+
+async function stubPrefsAndBoards(page: Page) {
+  await page.route('**/prefs/api/**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ preferences: {} })
+    })
+  )
+  await page.route('**/task/api/boards**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(boardsPayload())
+    })
+  )
+}
+
+test.describe('Session resilience', () => {
+  test('expired session still prompts and reloads, even though paint no longer waits on the handshake', async ({
+    page
+  }) => {
+    await seedFriendSession(page)
+    await stubPrefsAndBoards(page)
+
+    // Server says this key is no longer a friend — i.e. the session expired.
+    await page.route('**/task/api/session/handshake', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ userType: 'public', preferences: null })
+      })
+    )
+
+    await page.goto('/')
+
+    // The expiry handling now runs after the handshake resolves. It must still:
+    //  (a) downgrade the stored userType to match the server
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('hadoku_user_type')), {
+        timeout: 15000,
+        message: 'stored userType should be downgraded to public on expiry'
+      })
+      .toBe('public')
+
+    //  (b) tell the user
+    await expect(page.getByText(/session has expired/i)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('a failing handshake does not strand the user on the skeleton', async ({ page }) => {
+    await seedFriendSession(page)
+    await stubPrefsAndBoards(page)
+
+    await page.route('**/task/api/session/handshake', route =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"boom"}' })
+    )
+
+    await page.goto('/')
+
+    // App still mounts...
+    await expect(page.locator('.task-app-container')).toBeAttached({ timeout: 15000 })
+
+    // ...and the board sync still lands, because it authenticates off the session
+    // cookie rather than the handshake.
+    await expect(page.locator('.task-app__item-title', { hasText: TASK_TITLE })).toBeAttached({
+      timeout: 15000
+    })
+
+    // And we did NOT wrongly treat a 500 as an expiry.
+    expect(await page.evaluate(() => localStorage.getItem('hadoku_user_type'))).toBe('friend')
+  })
+})

--- a/src/hooks/useSessionInitialization.ts
+++ b/src/hooks/useSessionInitialization.ts
@@ -50,52 +50,62 @@ export function useSessionInitialization({
       // Get old sessionId before handshake
       const oldSessionId = getStoredSessionId()
 
-      // Perform handshake (for public users, this ensures stable sessionId in localStorage)
-      const handshakeResult = await performSessionHandshake(propsSessionId, userType)
+      // The handshake is server-side session bookkeeping (KV writes: preferences,
+      // session-info, authKey->session mapping). The only thing the client needs
+      // out of it is serverUserType, for the rare session-expiry case. So we start
+      // it here but do NOT await it before painting — awaiting it used to serialize
+      // handshake -> prefs -> boards and put the whole chain on the critical path.
+      const handshakePromise = performSessionHandshake(propsSessionId, userType)
 
-      // Check for session expiration - server userType differs from client
-      if (handshakeResult.serverUserType !== userType) {
+      /** Session expired server-side: tell the user and reload. */
+      function handleExpiry(serverUserType: string): boolean {
+        if (serverUserType === userType) return false
         logger.warn('[App] User type changed - session may have expired', {
           expected: userType,
-          actual: handshakeResult.serverUserType
+          actual: serverUserType
         })
-
-        // If user was authenticated but session expired (now treated as public)
-        if (userType !== 'public' && handshakeResult.serverUserType === 'public') {
-          // Update stored userType to match server
-          storeUserType(handshakeResult.serverUserType)
-
-          // Notify user and reload to reinitialize with correct state
+        if (userType !== 'public' && serverUserType === 'public') {
+          storeUserType(serverUserType)
           showToast('Your session has expired. Please enter your key again.', 'info')
-
-          // Small delay to let the toast show before reload
           setTimeout(() => {
             window.location.reload()
           }, 1500)
-          return
+          return true
         }
+        return false
       }
 
-      // Determine the effective sessionId to use
       let finalSessionId = propsSessionId
+
       if (userType === 'public') {
-        // Public users: use their stable localStorage sessionId
+        // Public handshake never touches the network — it just settles a stable
+        // sessionId in localStorage, which finalSessionId depends on. Awaiting it
+        // is free.
+        const handshakeResult = await handshakePromise
+        if (handleExpiry(handshakeResult.serverUserType)) return
+
         finalSessionId = getStoredSessionId() || propsSessionId
 
-        // Load preferences from the unified store (SDK). For public/anon the
-        // SDK serves its localStorage cache (prefs-api 401s anon, by design).
+        // For public/anon the SDK serves its localStorage cache (prefs-api 401s
+        // anon, by design).
         const prefs = await loadTaskPreferences('public', finalSessionId)
         setPreferences(prefs)
         setPreferencesLoaded(true)
       } else {
-        // Authenticated users: use the sessionId from props (from parent)
+        // Authenticated: finalSessionId is propsSessionId, known without the
+        // handshake. So prefs and the board sync can both run concurrently with
+        // the in-flight handshake instead of queueing behind it.
         finalSessionId = propsSessionId
 
-        // Load the merged (user + device) view from the unified store. The SDK
-        // already merges scopes + applies defaults, so the old localStorage-vs-
-        // server priority dance is gone (handshakeResult.preferences was always
-        // null client-side anyway). The one-shot legacy migration runs inside
-        // loadTaskPreferences on first load for this session.
+        // Kick the board sync off now. It's the long pole (the boards fetch is
+        // the slowest call in the load), and it needs nothing from the handshake
+        // or from prefs — useTasks already holds the right sessionId on first
+        // render. Starting it here rather than after both awaits is what gets
+        // tasks on screen sooner.
+        const boardSync = initialLoad().catch(err => {
+          logger.warn('[App] initialLoad failed in background', { error: String(err) })
+        })
+
         const prefs = await loadTaskPreferences(userType, finalSessionId)
         setPreferences(prefs)
         setPreferencesLoaded(true)
@@ -112,6 +122,14 @@ export function useSessionInitialization({
         if (displayName) {
           showToast(`Welcome back, ${displayName}`, 'success')
         }
+
+        // Expiry is handled off the critical path. If the key was revoked the
+        // board sync 401s and reports through onSyncError anyway; this just adds
+        // the explicit "enter your key again" prompt + reload.
+        void handshakePromise
+          .then(r => handleExpiry(r.serverUserType))
+          .catch(err => logger.warn('[App] handshake failed', { error: String(err) }))
+        void boardSync
       }
 
       // Set the effective sessionId for all hooks to use (only if different)
@@ -122,14 +140,14 @@ export function useSessionInitialization({
       // Unblock the shell as soon as preferences are resolved. useTasks's own
       // user-context effect has already hydrated tasks/boards from localStorage
       // by this point, so the shell renders with cached data immediately.
-      // initialLoad() (which talks to the API and replaces local state with the
-      // server view) runs in the background and surfaces fresh data when ready.
       setIsLoaded(true)
 
-      // Background data sync — don't gate first paint on the network round-trip.
-      void initialLoad().catch(err => {
-        logger.warn('[App] initialLoad failed in background', { error: String(err) })
-      })
+      if (userType === 'public') {
+        // Public has no syncFromApi; this just re-reads localStorage.
+        void initialLoad().catch(err => {
+          logger.warn('[App] initialLoad failed in background', { error: String(err) })
+        })
+      }
     }
 
     void initializeSession()

--- a/src/hooks/useTasks/index.ts
+++ b/src/hooks/useTasks/index.ts
@@ -87,13 +87,13 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userType, sessionId])
 
-  // Listen for broadcasted updates about tasks or boards
+  // Listen for broadcasted updates about tasks or boards.
+  //
+  // Keyed on the user context only — NOT on currentBoardId. The handler doesn't
+  // need it (reload() reads the live board from currentBoardIdRef), so including
+  // it just tore the channel down and rebuilt it on every board switch.
   useEffect(() => {
-    logger.info('[useTasks] Setting up BroadcastChannel listener', {
-      currentBoardId,
-      userType,
-      sessionId
-    })
+    logger.info('[useTasks] Setting up BroadcastChannel listener', { userType, sessionId })
     try {
       const bcListener = new BroadcastChannel('tasks')
       bcListener.onmessage = e => {
@@ -101,7 +101,7 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
         logger.info('[useTasks] BroadcastChannel message received', {
           msg,
           sessionId: SESSION_ID,
-          currentBoardId,
+          currentBoardId: currentBoardIdRef.current,
           currentContext: { userType, sessionId }
         })
 
@@ -122,13 +122,13 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
 
         if (msg.type === 'tasks-updated' || msg.type === 'boards-updated') {
           logger.info('[useTasks] BroadcastChannel: triggering reload for currentBoardId', {
-            currentBoardId
+            currentBoardId: currentBoardIdRef.current
           })
           void reload()
         }
       }
       return () => {
-        logger.info('[useTasks] Cleaning up BroadcastChannel listener', { currentBoardId })
+        logger.info('[useTasks] Cleaning up BroadcastChannel listener')
         bcListener.close()
       }
     } catch (err) {
@@ -137,7 +137,7 @@ export function useTasks({ userType, sessionId, onSyncError }: UseTasksProps) {
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentBoardId, userType, sessionId])
+  }, [userType, sessionId])
 
   async function addTask(
     input: string,

--- a/worker/src/session.ts
+++ b/worker/src/session.ts
@@ -126,16 +126,21 @@ export async function updateSessionMapping(
   kv: KVNamespace,
   authKey: string,
   sessionId: string,
-  maxRetries = 10
+  maxRetries = 10,
+  // Callers that just wrote session-info themselves can skip the existence
+  // read — it's a global KV round-trip whose answer they already know.
+  sessionInfoKnownToExist = false
 ): Promise<void> {
   // Verify session-info exists before adding to mapping
   // This prevents "mystery sessions" that have no session data
-  const sessionInfo = await getSessionInfo(kv, sessionId)
-  if (!sessionInfo) {
-    logger.warn(
-      `[SessionMapping] Cannot add session ${maskSessionId(sessionId)} - no session-info exists`
-    )
-    return
+  if (!sessionInfoKnownToExist) {
+    const sessionInfo = await getSessionInfo(kv, sessionId)
+    if (!sessionInfo) {
+      logger.warn(
+        `[SessionMapping] Cannot add session ${maskSessionId(sessionId)} - no session-info exists`
+      )
+      return
+    }
   }
 
   const key = sessionMappingKey(authKey)
@@ -263,27 +268,31 @@ export async function handleSessionHandshake(
   let isNewSession = true
   let sessionIdToDelete: string | null = null
 
-  // Try to load preferences from oldSessionId (explicit migration)
-  if (oldSessionId) {
-    preferences = await getPreferencesBySessionId(kv, oldSessionId)
-    if (preferences) {
-      migratedFrom = oldSessionId
-      isNewSession = false
-      sessionIdToDelete = oldSessionId // Only delete if explicitly migrating
-    }
+  // The old-session preference lookup and the authKey->session mapping lookup are
+  // independent, and every KV read is a global round-trip. Fetch them together
+  // instead of in series. The mapping is needed again below (migration cleanup),
+  // so reading it up front costs nothing extra in the common path.
+  const [oldSessionPrefs, mapping] = await Promise.all([
+    oldSessionId ? getPreferencesBySessionId(kv, oldSessionId) : Promise.resolve(null),
+    getSessionMapping(kv, authKey)
+  ])
+
+  // Preferences from oldSessionId (explicit migration)
+  if (oldSessionId && oldSessionPrefs) {
+    preferences = oldSessionPrefs
+    migratedFrom = oldSessionId
+    isNewSession = false
+    sessionIdToDelete = oldSessionId // Only delete if explicitly migrating
   }
 
-  // If oldSessionId not provided or not found, try authKey mapping as fallback
+  // Otherwise fall back to the authKey mapping's last session.
   // Note: We DON'T delete this - it might be another device still using it
-  if (!preferences) {
-    const mapping = await getSessionMapping(kv, authKey)
-    if (mapping && mapping.lastSessionId) {
-      preferences = await getPreferencesBySessionId(kv, mapping.lastSessionId)
-      if (preferences) {
-        migratedFrom = mapping.lastSessionId
-        isNewSession = false
-        // DON'T mark for deletion - this might be a new device
-      }
+  if (!preferences && mapping?.lastSessionId) {
+    preferences = await getPreferencesBySessionId(kv, mapping.lastSessionId)
+    if (preferences) {
+      migratedFrom = mapping.lastSessionId
+      isNewSession = false
+      // DON'T mark for deletion - this might be a new device
     }
   }
 
@@ -292,24 +301,6 @@ export async function handleSessionHandshake(
     preferences = { ...DEFAULT_PREFERENCES }
   }
 
-  // Save preferences to newSessionId
-  await savePreferencesBySessionId(kv, newSessionId, preferences)
-
-  // Delete old preferences and session info ONLY if explicitly migrating
-  if (sessionIdToDelete && sessionIdToDelete !== newSessionId) {
-    await kv.delete(preferencesKey(sessionIdToDelete))
-    await kv.delete(sessionInfoKey(sessionIdToDelete))
-
-    // Remove old sessionId from mapping
-    const mapping = await getSessionMapping(kv, authKey)
-    if (mapping) {
-      mapping.sessionIds = mapping.sessionIds.filter(id => id !== sessionIdToDelete)
-      await kv.put(sessionMappingKey(authKey), JSON.stringify(mapping))
-    }
-  }
-
-  // Create session info for newSessionId FIRST (before updating mapping)
-  // This ensures session-info exists when updateSessionMapping checks for it
   const now = new Date().toISOString()
   const sessionInfo: SessionInfo = {
     sessionId: newSessionId,
@@ -318,11 +309,32 @@ export async function handleSessionHandshake(
     createdAt: now,
     lastAccessedAt: now
   }
-  await saveSessionInfo(kv, sessionInfo)
 
-  // Add new sessionId to mapping (AFTER session-info is created)
-  // This prevents "mystery sessions" in the mapping without session-info
-  await updateSessionMapping(kv, authKey, newSessionId)
+  // Preferences and session-info are independent writes — issue them together.
+  // The mapping update must still land AFTER session-info exists, otherwise the
+  // mapping can reference a session that has no session-info ("mystery sessions").
+  await Promise.all([
+    savePreferencesBySessionId(kv, newSessionId, preferences),
+    saveSessionInfo(kv, sessionInfo)
+  ])
+
+  // Delete old preferences and session info ONLY if explicitly migrating.
+  // Reuses the mapping already read above.
+  if (sessionIdToDelete && sessionIdToDelete !== newSessionId) {
+    const cleanup: Promise<unknown>[] = [
+      kv.delete(preferencesKey(sessionIdToDelete)),
+      kv.delete(sessionInfoKey(sessionIdToDelete))
+    ]
+    if (mapping) {
+      mapping.sessionIds = mapping.sessionIds.filter(id => id !== sessionIdToDelete)
+      cleanup.push(kv.put(sessionMappingKey(authKey), JSON.stringify(mapping)))
+    }
+    await Promise.all(cleanup)
+  }
+
+  // Add new sessionId to mapping (AFTER session-info is created).
+  // We wrote session-info in the Promise.all above, so skip the existence re-read.
+  await updateSessionMapping(kv, authKey, newSessionId, 10, true)
 
   // Clean up stale sessions (30+ days old) in the background
   // This runs asynchronously and won't block the handshake response


### PR DESCRIPTION
## The problem

Session init awaited the handshake, **then** prefs, **then** kicked off the board sync. Measured against prod, that's the entire cold load:

| Call | prod median |
|---|---|
| `POST /task/api/session/handshake` | **577ms** |
| `GET /prefs/api/v1/task` | 169ms |
| `GET /task/api/boards` | 373–1003ms |

First paint was gated on the two slowest calls, and the board fetch — the long pole — didn't even *start* until both had returned.

Nothing required that order. For an authenticated user `finalSessionId` is `propsSessionId`, known *before* the handshake runs (App.tsx initialises `effectiveSessionId` to it on the first render). The only thing the client needs back from the handshake is `serverUserType`, for the rare session-expiry case.

## Changes

**Client** — fire handshake, prefs and the board sync concurrently. Expiry is handled when the handshake resolves, off the critical path. Public users still await their handshake, but that path never touches the network (it just settles a stable sessionId in localStorage), so it's free.

**Worker** — the handshake ran 6+ Cloudflare KV ops strictly in series, and KV writes are global round-trips:
- the old-session preference read and the authKey→session mapping read are independent → fetch together
- the preference write and the session-info write are independent → issue together
- the mapping update still lands *after* session-info (the one ordering that matters — otherwise the mapping can name a session with no session-info)
- `updateSessionMapping` re-read session-info to check it exists; the handshake just wrote it, so skip that round-trip

**useTasks** — the `BroadcastChannel` effect was keyed on `currentBoardId`, so every board switch tore the channel down and rebuilt it. The handler reads the live board from `currentBoardIdRef` now, so it's keyed on user context only.

## Measured

A/B with prod median latencies stubbed (handshake 575ms, prefs 170ms, boards 400ms). Same stubs, same machine — only the code differs:

| | serial (before) | parallel (after) |
|---|---|---|
| handshake issued | +0ms | +0ms |
| prefs issued | **+716ms** | **+165ms** |
| boards issued | **+909ms** | **+0ms** |
| app mounted | **+1498ms** | **+446ms** |
| server data on screen | **+1502ms** | **+506ms** |

**App mount 3.4× faster. Data on screen 3× faster.** Data now lands *before the handshake has even returned*.

Handshake server time, against a KV simulating real latency (40ms read / 150ms write), with all 16 behaviour assertions (preference migration, session-info, mapping updates, cleanup) passing unchanged:

- returning user: **1180ms → 582ms**
- new user: **610ms → 431ms**

## Test

`e2e/cold-load-serialization.spec.ts` asserts on **request ordering** — boards and prefs must be issued before the handshake *response* arrives — rather than a latency budget. That's pure causality, so it can't go flaky under a loaded parallel suite (an earlier budget-based version did exactly that). It fails on the old code:

```
Error: board sync must be issued while the handshake is still in flight, not after it returns
Expected: < 1197
Received:   1495
```

Full suite: 38 passed, 0 failed. Lint 0 problems, both tsconfigs clean, build clean.

## Not changed (reported separately)

`GET /session/whoami` is fetched **twice** per load — hadoku_site has two independent callers (`mf-loader.js` and `auth-client.ts`) that don't know about each other. Different repo, different deploy chain.

React render counts are healthy and were left alone: 7 on cold load, 4 on board switch, **0 while idle**. No re-render pathology to fix.