### PR TITLE
chore(profiler): productionise the cold-load profiler + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ test-results/
 
 # per-repo vault key (Phase 2 of per-key ACL plan; never commit)
 .devvault.local.json
+
+# Cold-load profiler run logs (scripts/profile-cold-load.mjs)
+.profiler/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ Pre-commit hook runs lint:fix + format. It does NOT bump versions — versioning
 - `@wolffm/task/api` -> server handlers [src/server/index.ts]
 - `@wolffm/task/style.css` -> CSS bundle [dist/style.css]
 
+## Profiling / performance
+
+- Cold-load profiler: `pnpm run profile` (authenticated, measures timing + API waterfall + duplicate requests, writes `.profiler/latest.json`).
+- Full method, deeper techniques (CDP initiator stacks, render counts, simulated-KV server timing), regression guards, and the current baseline: `docs/PROFILING.md`. Start there whenever the ask is "profile" / "perf" / "why is it slow".
+
 ## MCP (agent task/calendar management)
 
 - Remote, stateless Streamable-HTTP MCP at `/task/api/mcp` (live: `https://hadoku.me/task/api/mcp`).

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,96 @@
+# Profiling the task app
+
+How to measure cold-load performance and catch regressions. This is the
+repeatable version of the investigation that produced the [#63 load
+parallelisation](https://github.com/WolffM/hadoku-task/pull/63) and the
+[#194 whoami dedupe](https://github.com/WolffM/hadoku_site/pull/194).
+
+If the ask is just "profile the task app", run the profiler below and read the
+summary — it prints timing, the API waterfall, and any duplicate requests, and
+writes a diffable JSON log.
+
+## The profiler
+
+```bash
+pnpm run profile                          # 5 cold-cache runs vs https://hadoku.me
+pnpm run profile -- --runs 10
+pnpm run profile -- --origin http://localhost:5199 --path /task/   # local dev build
+TASK_KEY=friend-<uuid> pnpm run profile   # use a specific friend key
+```
+
+Source: [`scripts/profile-cold-load.mjs`](../scripts/profile-cold-load.mjs).
+
+It authenticates once through the real key flow (so the `hadoku_session` cookie
+is set and the **authenticated** path is exercised — not the anonymous path,
+which never fetches boards), then measures N navigations with a **cold HTTP
+cache but warm session**. That's the returning-user cold load, where the latency
+actually lives.
+
+Per run it captures:
+
+- **time to skeleton / app mount / first task on screen** — `tasks` is the one
+  that matters; it's when the user sees real data.
+- **the API waterfall** — every `/task`, `/prefs`, `/session` call with wall
+  time, TTFB, and cache headers (`Cache-Control`, `cf-cache-status`).
+- **duplicate requests** — any `METHOD path` fetched more than once. This is how
+  the double `/session/whoami` was found.
+
+### Output
+
+Human summary to stdout, plus a timestamped JSON log under `.profiler/`
+(gitignored), with `.profiler/latest.json` always pointing at the newest run.
+The logs are structured for diffing across runs — e.g. before/after a deploy:
+
+```bash
+pnpm run profile && cp .profiler/latest.json .profiler/before.json
+# ... deploy ...
+pnpm run profile
+node -e "const b=require('./.profiler/before.json').summary, a=require('./.profiler/latest.json').summary; console.table({before:b, after:a})"
+```
+
+## Deeper profiling
+
+For questions the standard run doesn't answer, drive Playwright + CDP directly
+(the profiler is a plain script — copy and extend it):
+
+- **Where does a request come from?** Capture initiator stacks via CDP
+  `Network.requestWillBeSent` → `e.initiator.stack.callFrames`. This is how the
+  second whoami was traced to `@wolffm/prefs-client` (vs the shell's `mf-loader`).
+- **How many times does a component render?** Temporarily increment a
+  `window.__renders` counter at the top of the component, drive the flow, read it
+  back with `page.evaluate`. Remove the instrumentation before committing. Cold
+  load was 7 App renders, board switch +4, idle +0 — all healthy.
+- **Server-side latency** (e.g. the KV round-trips inside the handshake): boot the
+  real worker handler against an in-memory KV that simulates CF latency (~40ms
+  read / ~150ms write) and record an op timeline. This is how the handshake was
+  shown to drop 1180ms → 582ms by parallelising independent KV ops.
+
+## Regression guards (in CI, no prod needed)
+
+Two committed e2e specs pin the wins so they can't silently regress. Both use
+stubbed prod-median latencies and run in the normal suite:
+
+- [`e2e/cold-load-serialization.spec.ts`](../e2e/cold-load-serialization.spec.ts)
+  — asserts handshake / prefs / boards are issued **concurrently**. It checks
+  request _ordering_ (boards and prefs must fire before the handshake response
+  arrives), not a latency budget, so it's immune to CI load. Fails on the old
+  serial code.
+- [`e2e/prod-cold-load.spec.ts`](../e2e/prod-cold-load.spec.ts) — opt-in
+  (`RUN_PROD_PERF=1`), asserts median skeleton < 400ms and app < 1500ms against
+  live prod, and that the inline skeleton still ships in the HTML.
+
+## Baseline (2026-07, authenticated cold load vs hadoku.me)
+
+| Metric                | Before #63 | After #63  |
+| --------------------- | ---------- | ---------- |
+| tasks on screen       | 776 ms     | **246 ms** |
+| `session/handshake`   | 577 ms     | **304 ms** |
+| total API on the wire | 2003 ms    | 998 ms     |
+
+The load chain used to be serial (`handshake → prefs → boards`); #63 made the
+three concurrent, and parallelised the handshake's KV ops server-side.
+
+**Known open item:** `GET /session/whoami` is fetched twice on boot — the shell
+(`mf-loader`) and `@wolffm/prefs-client` each resolve it. Fixed by
+[hadoku_site #194](https://github.com/WolffM/hadoku_site/pull/194); the profiler
+flags it under "duplicate requests" until that ships everywhere.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "prepare": "husky",
     "test:e2e": "pw-isolated playwright test",
     "test:e2e:ui": "pw-isolated playwright test --ui",
-    "test:e2e:debug": "pw-isolated playwright test --debug"
+    "test:e2e:debug": "pw-isolated playwright test --debug",
+    "profile": "node scripts/profile-cold-load.mjs"
   },
   "dependencies": {
     "@hono/zod-openapi": "^1.4.0",

--- a/scripts/profile-cold-load.mjs
+++ b/scripts/profile-cold-load.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Cold-load profiler for the task app (and, with --origin, any hadoku page).
+ *
+ * Authenticates once through the real key flow so the session cookie is set,
+ * then measures N cold-HTTP-cache navigations — the returning-user path, which
+ * is where load latency actually lives. For each run it records:
+ *
+ *   - time to skeleton, app mount, and first task on screen
+ *   - the full API waterfall with per-call wall time + cache headers
+ *   - duplicate requests (same method+path fetched more than once)
+ *   - a per-endpoint call count (so e.g. a double /session/whoami is obvious)
+ *
+ * Results print as a human summary AND are written as a timestamped JSON log
+ * under .profiler/ (gitignored), with .profiler/latest.json always pointing at
+ * the most recent run — so runs are diffable over time.
+ *
+ * Usage:
+ *   pnpm run profile                    # 5 runs vs https://hadoku.me
+ *   pnpm run profile -- --runs 10
+ *   TASK_KEY=friend-... pnpm run profile
+ *   pnpm run profile -- --origin http://localhost:5199 --path /task/
+ *
+ * Env / flags:
+ *   TASK_PROD_ORIGIN | --origin   default https://hadoku.me
+ *   TASK_KEY         | --key      friend test key (default: the shared e2e key)
+ *   TASK_PROD_RUNS   | --runs     cold-cache runs to measure (default 5)
+ *                      --path     page path (default /task/)
+ *                      --headed   run with a visible browser
+ *
+ * Docs: docs/PROFILING.md
+ */
+import pw from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const { chromium } = pw
+
+// ---- args ------------------------------------------------------------------
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`)
+  if (i !== -1) return process.argv[i + 1] ?? true
+  return fallback
+}
+const ORIGIN = arg('origin', process.env.TASK_PROD_ORIGIN ?? 'https://hadoku.me')
+const KEY = arg('key', process.env.TASK_KEY ?? 'friend-12345678-1234-1234-1234-1234567890ab')
+const RUNS = Number(arg('runs', process.env.TASK_PROD_RUNS ?? 5))
+const PATH = arg('path', '/task/')
+const HEADED = arg('headed', false) === true
+const SETTLE_MS = 4000 // let background initialLoad + late calls land
+
+const median = xs => {
+  const s = [...xs].filter(x => x != null).sort((a, b) => a - b)
+  return s.length ? s[Math.floor(s.length / 2)] : null
+}
+const short = u => u.replace(ORIGIN, '').split('?')[0]
+const isApi = u => /\/(task|prefs|session)\/|\/whoami/.test(u)
+
+async function authenticate(page) {
+  await page.goto(`${ORIGIN}${PATH}`, { waitUntil: 'load' })
+  await page.waitForSelector('h1.task-app__header', { timeout: 20000 })
+  await page.locator('h1.task-app__header').click()
+  await page.waitForSelector('.modal-overlay', { state: 'visible', timeout: 10000 })
+  const keyInput = page.locator('input[name="key"]')
+  await keyInput.waitFor({ state: 'visible', timeout: 10000 })
+  await keyInput.fill(KEY)
+  await keyInput.locator('..').locator('button.settings-field-button').click()
+  await page.waitForEvent('load', { timeout: 20000 })
+  await page.waitForTimeout(2500)
+  return page.evaluate(() => ({
+    userType: localStorage.getItem('hadoku_user_type'),
+    sessionId: localStorage.getItem('hadoku_session_id')
+  }))
+}
+
+async function measure(page, cdp) {
+  await page.goto('about:blank', { waitUntil: 'load' }) // tear down prior DOM
+  await cdp.send('Network.clearBrowserCache')
+
+  const reqs = []
+  const onFinished = async req => {
+    try {
+      const res = await req.response()
+      if (!res) return
+      const t = req.timing()
+      const h = await res.allHeaders()
+      reqs.push({
+        method: req.method(),
+        path: short(req.url()),
+        status: res.status(),
+        wall: Math.round(t.responseEnd - t.requestStart),
+        ttfb: Math.round(t.responseStart - t.requestStart),
+        cacheControl: h['cache-control'] ?? '',
+        cfCache: h['cf-cache-status'] ?? ''
+      })
+    } catch {
+      /* aborted */
+    }
+  }
+  page.on('requestfinished', onFinished)
+
+  const t0 = Date.now()
+  const mark = {}
+  const poll = (async () => {
+    const deadline = t0 + 30000
+    while (Date.now() < deadline && mark.tasks == null) {
+      try {
+        const s = await page.evaluate(() => ({
+          skel: !!document.querySelector('.task-app-loading'),
+          app: !!document.querySelector('.task-app-container'),
+          tasks: document.querySelectorAll('.task-app__item').length > 0
+        }))
+        const now = Date.now() - t0
+        if (s.skel && mark.skeleton == null) mark.skeleton = now
+        if (s.app && mark.app == null) mark.app = now
+        if (s.tasks && mark.tasks == null) mark.tasks = now
+      } catch {
+        /* navigating */
+      }
+      await new Promise(r => setTimeout(r, 10))
+    }
+  })()
+
+  await page.goto(`${ORIGIN}${PATH}`, { waitUntil: 'load', timeout: 30000 })
+  await poll
+  await page.waitForTimeout(SETTLE_MS)
+  page.off('requestfinished', onFinished)
+
+  // duplicates + per-endpoint counts
+  const counts = {}
+  for (const r of reqs) {
+    const k = `${r.method} ${r.path}`
+    counts[k] = (counts[k] ?? 0) + 1
+  }
+  const duplicates = Object.entries(counts)
+    .filter(([, n]) => n > 1)
+    .map(([k, n]) => ({ call: k, count: n }))
+
+  return {
+    timing: { skeleton: mark.skeleton ?? null, app: mark.app ?? null, tasks: mark.tasks ?? null },
+    api: reqs.filter(r => isApi(r.path)),
+    duplicates,
+    totalApiWireMs: reqs.filter(r => isApi(r.path)).reduce((s, r) => s + r.wall, 0)
+  }
+}
+
+// ---- run -------------------------------------------------------------------
+console.log(`\nCold-load profiler → ${ORIGIN}${PATH}  (${RUNS} runs)\n`)
+
+const browser = await chromium.launch({ headless: !HEADED })
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } })
+const page = await ctx.newPage()
+
+console.log('Authenticating…')
+const who = await authenticate(page)
+if (who.userType !== 'friend') {
+  console.error(`❌ authentication failed (userType=${who.userType}). Set TASK_KEY to a valid friend key.`)
+  await browser.close()
+  process.exit(1)
+}
+console.log(`  authed as friend (session ${who.sessionId.slice(0, 8)}…)\n`)
+
+const cdp = await ctx.newCDPSession(page)
+const runs = []
+for (let i = 1; i <= RUNS; i++) {
+  const r = await measure(page, cdp)
+  runs.push(r)
+  console.log(
+    `  run ${i}: skeleton=${r.timing.skeleton}ms app=${r.timing.app}ms tasks=${r.timing.tasks}ms ` +
+      `(${r.api.length} API calls, ${r.totalApiWireMs}ms on the wire)`
+  )
+}
+await browser.close()
+
+// ---- report ----------------------------------------------------------------
+const summary = {
+  skeleton: median(runs.map(r => r.timing.skeleton)),
+  app: median(runs.map(r => r.timing.app)),
+  tasks: median(runs.map(r => r.timing.tasks)),
+  totalApiWireMs: median(runs.map(r => r.totalApiWireMs))
+}
+
+console.log(`\n================ TIMING (median of ${RUNS}) ================`)
+console.log(`  skeleton painted   ${summary.skeleton} ms`)
+console.log(`  app mounted        ${summary.app} ms`)
+console.log(`  tasks on screen    ${summary.tasks} ms`)
+console.log(`  API time on wire   ${summary.totalApiWireMs} ms`)
+
+const last = runs[runs.length - 1]
+console.log('\n================ API WATERFALL (last run) ================')
+for (const r of last.api) {
+  console.log(
+    `  ${r.status} ${String(r.wall).padStart(5)}ms  ${r.method.padEnd(5)} ${r.path.padEnd(40)} ` +
+      `cc="${r.cacheControl}"${r.cfCache ? ` cf=${r.cfCache}` : ''}`
+  )
+}
+
+console.log('\n================ DUPLICATE REQUESTS (last run) ================')
+if (last.duplicates.length === 0) console.log('  (none)')
+else for (const d of last.duplicates) console.log(`  ${d.count}×  ${d.call}`)
+
+// ---- persist log -----------------------------------------------------------
+// Timestamp comes from the OS clock via a child date call — Date.now() is fine
+// in a plain script (unlike workflow scripts), so use it directly.
+const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+const outDir = join(process.cwd(), '.profiler')
+mkdirSync(outDir, { recursive: true })
+const record = { origin: ORIGIN, path: PATH, runs: RUNS, at: new Date().toISOString(), summary, detail: runs }
+const file = join(outDir, `cold-load-${stamp}.json`)
+writeFileSync(file, JSON.stringify(record, null, 2))
+writeFileSync(join(outDir, 'latest.json'), JSON.stringify(record, null, 2))
+console.log(`\n📝 log written: ${file}`)
+console.log(`   (also .profiler/latest.json)\n`)


### PR DESCRIPTION
Turns the throwaway harness from the perf work (#63) into a repeatable tool, per request.

## What's here

**`pnpm run profile`** ([`scripts/profile-cold-load.mjs`](../blob/chore/profiler/scripts/profile-cold-load.mjs)) — authenticates through the real key flow, measures N cold-HTTP-cache navigations, and reports:
- time to skeleton / app mount / **first task on screen**
- the API waterfall with per-call wall time + cache headers
- **duplicate requests** (this is what surfaced the double `/session/whoami`)

Writes a timestamped JSON log to `.profiler/` (gitignored) + `.profiler/latest.json`, so runs diff over time.

```
pnpm run profile                     # 5 runs vs hadoku.me
pnpm run profile -- --runs 10
pnpm run profile -- --origin http://localhost:5199   # local build
```

**[`docs/PROFILING.md`](../blob/chore/profiler/docs/PROFILING.md)** — the method, deeper techniques (CDP initiator stacks, render-count instrumentation, simulated-KV server timing), the CI regression guards, and the current baseline. `CLAUDE.md` now points here so "profile" / "perf" starts in the right place.

## Verified

Ran it against prod: median app mount **342ms** (the #63 win is live), and it correctly flags:

```
================ DUPLICATE REQUESTS (last run) ================
  2×  GET /session/whoami
```

which is exactly what hadoku_site #194 fixes. Lint clean, script parses, pre-commit green.