### PR TITLE
fix(ci): auto-update now dispatches publish so dep bumps reach prod

### DIFF
--- a/.github/workflows/update-wolffm.yml
+++ b/.github/workflows/update-wolffm.yml
@@ -14,6 +14,7 @@ concurrency:
 permissions:
   contents: write
   packages: read
+  actions: write # dispatch publish.yml after an auto-update commit (see below)
 
 jobs:
   update:
@@ -53,6 +54,9 @@ jobs:
           pnpm update -r "@wolffm/*" --latest
 
       - name: Commit and push if changed
+        env:
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -70,9 +74,29 @@ jobs:
           git add $FILES
           git commit -m "chore: auto-update @wolffm/* to latest"
 
+          # Push, then explicitly dispatch publish.yml. This push is authenticated
+          # with GITHUB_TOKEN, and GitHub refuses to trigger `on: push` workflows
+          # from a GITHUB_TOKEN push (loop-prevention) — so publish.yml would never
+          # fire on its own, and the freshly-bumped @wolffm/* deps would sit in the
+          # lockfile without ever being rebuilt into a published @wolffm/task. The
+          # dispatch closes that gap; it only runs when we actually pushed a change.
           for i in 1 2 3; do
             if git push; then
-              echo "✅ Pushed"
+              echo "✅ Pushed — dispatching publish.yml so the bump reaches the registry"
+              # REST dispatch (no gh dependency on the self-hosted runner). Needs
+              # the actions:write permission declared above. Non-fatal: if it fails
+              # the bump is still committed, just not yet published.
+              http=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/$REPO/actions/workflows/publish.yml/dispatches" \
+                -d '{"ref":"main"}') || true
+              if [ "$http" = "204" ]; then
+                echo "✅ publish.yml dispatched"
+              else
+                echo "⚠️  publish dispatch returned HTTP $http — run it manually: gh workflow run publish.yml --ref main"
+              fi
               exit 0
             fi
             echo "Push failed (attempt $i), rebasing..."


### PR DESCRIPTION
## The gap (the thing that bit us with prefs-client)

`update-wolffm.yml` bumps `@wolffm/*` in the lockfile and pushes the commit as `github-actions[bot]` using `GITHUB_TOKEN`.

**GitHub refuses to trigger `on: push` workflows from a `GITHUB_TOKEN` push** — it's their infinite-loop guard. So `publish.yml` (which triggers on push) never fired on the auto-update commit. The freshly-bumped deps sat in the lockfile and were never rebuilt into a published `@wolffm/task`.

Result: a transitive dep update (like the whoami-dedupe `prefs-client 1.0.4`) silently never reached prod. It looked automatic — the auto-update ran green — but the chain dead-ended. Getting it to prod took a manual `gh workflow run publish.yml`.

It never surfaced before because normal changes arrive via human/PR pushes, which *do* trigger publish. Only a pure auto-update commit hits this hole.

## The fix

After a successful push, `update-wolffm.yml` explicitly dispatches `publish.yml` via the REST API:

```bash
curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
  ".../actions/workflows/publish.yml/dispatches" -d '{"ref":"main"}'
```

- `curl`, not `gh` — no dependency on the self-hosted runner having the CLI.
- Guarded by the `if git push` success branch, so it only fires on the change path; the no-op early-exit is untouched.
- Adds `actions: write` to the job (required to dispatch).

`publish.yml` then auto-bumps `@wolffm/task` and fires its existing `packages_updated` dispatch to hadoku_site — so the chain completes end to end, no human in the loop.

**No loop risk:** `publish.yml` doesn't dispatch back into `update-wolffm`, and a task self-publish that pinged `update-wolffm` would find no newer `@wolffm` dep and no-op.

## Verification

The dispatch is the exact REST call I ran by hand to push prefs-client 1.0.4 to prod (that manual `workflow_dispatch` produced `@wolffm/task@3.4.89`, now live) — this just automates it. YAML validated. After merge I'll do a no-op run to confirm the existing path is unaffected.