### PR TITLE
feat(task-ui-components): AppHeader + ConnectedSettings — unified ecosystem header

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,8 @@ export default [
         setInterval: 'readonly',
         clearInterval: 'readonly',
         fetch: 'readonly',
+        AbortSignal: 'readonly',
+        AbortController: 'readonly',
         alert: 'readonly',
         confirm: 'readonly',
         prompt: 'readonly',

--- a/task-ui-components/README.md
+++ b/task-ui-components/README.md
@@ -34,6 +34,20 @@ This allows the package to bundle its CSS automatically. **This is a one-time se
 
 ## Components
 
+### AppHeader (Overview)
+
+The ecosystem-standard top bar for every hadoku.me app: title on the left, an
+action bar on the right holding the theme picker and the unified settings gear.
+Enforces the shared header contract so child apps stop drifting. See
+[Unified app header](#unified-app-header-recommended-for-hadokume-apps) below.
+
+### ConnectedSettings (Overview)
+
+The unified per-user settings gear + popout (access tier, display name, global
+content-visibility level, auth-key swap). "Connected": it self-wires to the
+hadoku.me edge-router via same-origin fetches, so it needs zero props. Injected
+automatically by `AppHeader`; can also be used standalone.
+
 ### ThemePicker (Overview)
 
 A gorgeous theme picker with light/dark pill design. Fully customizable to work with any theme system.
@@ -59,6 +73,51 @@ Generic settings dialog with section-based organization and multiple field types
 Toast notification system with success, error, and info variants.
 
 ## Usage
+
+### Unified app header (recommended for hadoku.me apps)
+
+Every app under `hadoku.me` should render the same top bar. `AppHeader` gives
+you the enforced layout — title left, `[ status? · ThemePicker · Settings ]`
+right — and injects the hadoku-wired `ConnectedSettings` gear for you. Pass your
+own `ConnectedThemePicker` (theme state stays app-side):
+
+```tsx
+import { AppHeader, ConnectedThemePicker } from '@wolffm/task-ui-components'
+import { useTheme, THEME_FAMILIES, THEME_ICON_MAP } from '@wolffm/themes'
+import '@wolffm/themes/style.css'
+import '@wolffm/task-ui-components/theme-picker.css'
+import '@wolffm/task-ui-components/app-header.css'
+
+function App() {
+  const { theme, setTheme } = useTheme()
+  return (
+    <>
+      <AppHeader
+        title="Print Tool"
+        themePicker={
+          <ConnectedThemePicker
+            themeFamilies={THEME_FAMILIES}
+            currentTheme={theme}
+            onThemeChange={setTheme}
+            getThemeIcon={t => {
+              const Icon = THEME_ICON_MAP[t as keyof typeof THEME_ICON_MAP]
+              return Icon ? <Icon /> : null
+            }}
+          />
+        }
+      />
+      {/* app body — the app's own concern */}
+    </>
+  )
+}
+```
+
+`ConnectedSettings` self-resolves the caller's tier/name via `/session/whoami`
+and hits the edge-router's `/session/*` + `/prefs/api/v1/content-level` routes.
+Off `hadoku.me` (e.g. Storybook) every call resolves to a safe default and the
+gear renders a read-only shell — it never throws. Pass `settingsProps={{ userType,
+name }}` when the app already knows the identity to skip the extra fetch, or
+`showSettings={false}` to omit the gear.
 
 ### Quick Start with @wolffm/themes (Recommended)
 

--- a/task-ui-components/package.json
+++ b/task-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/task-ui-components",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Reusable UI components with Bento grid and metallic gradient support",
   "type": "module",
   "main": "dist/index.js",
@@ -21,6 +21,7 @@
       "require": "./dist/index.js"
     },
     "./theme-picker.css": "./dist/theme-picker.css",
+    "./app-header.css": "./dist/app-header.css",
     "./toaster.css": "./dist/toaster.css",
     "./context-menu.css": "./dist/context-menu.css",
     "./bento.css": "./dist/bento.css",
@@ -29,9 +30,9 @@
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly && node ../scripts/fix-imports.cjs dist && pnpm run copy-css",
     "typecheck": "tsc --noEmit",
-    "copy-css": "node -e \"const fs=require('fs'); fs.copyFileSync('dist/task-ui-components.css', 'dist/styles.css'); fs.copyFileSync('src/theme-picker.css', 'dist/theme-picker.css'); fs.copyFileSync('src/toaster.css', 'dist/toaster.css'); fs.copyFileSync('src/context-menu.css', 'dist/context-menu.css'); fs.copyFileSync('src/bento.css', 'dist/bento.css')\"",
+    "copy-css": "node -e \"const fs=require('fs'); fs.copyFileSync('dist/task-ui-components.css', 'dist/styles.css'); fs.copyFileSync('src/theme-picker.css', 'dist/theme-picker.css'); fs.copyFileSync('src/app-header.css', 'dist/app-header.css'); fs.copyFileSync('src/toaster.css', 'dist/toaster.css'); fs.copyFileSync('src/context-menu.css', 'dist/context-menu.css'); fs.copyFileSync('src/bento.css', 'dist/bento.css')\"",
     "prepublishOnly": "pnpm run build",
-    "_comment": "copy-css requires source CSS files: theme-picker.css, toaster.css, context-menu.css (validated in CI)"
+    "_comment": "copy-css requires source CSS files: theme-picker.css, app-header.css, toaster.css, context-menu.css (validated in CI)"
   },
   "keywords": [
     "theme-picker",

--- a/task-ui-components/src/app-header.css
+++ b/task-ui-components/src/app-header.css
@@ -1,0 +1,235 @@
+/* AppHeader + ConnectedSettings styles for @wolffm/task-ui-components.
+ *
+ * All colors come from @wolffm/themes semantic tokens so the header themes with
+ * everything else. Import alongside theme-picker.css:
+ *   import '@wolffm/task-ui-components/app-header.css'
+ */
+
+/* ── Header layout ─────────────────────────────────────────────────────────
+ * Title left, action bar right, vertically centered. Full width of whatever
+ * column the app places it in. */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.app-header__title {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: var(--hdk-text-lg);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.app-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* ── ConnectedSettings: gear toggle ────────────────────────────────────────
+ * Round toggle matched to .theme-toggle-btn so the gear sits flush next to the
+ * theme button in the same row. */
+.settings-popout {
+  position: relative;
+  display: inline-flex;
+}
+
+.settings-toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: var(--color-text);
+  opacity: 0.7;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+  width: 32px;
+  height: 32px;
+  box-sizing: border-box;
+}
+.settings-toggle-btn:hover {
+  background-color: var(--color-primary-hover);
+  opacity: 1;
+}
+.settings-toggle-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary);
+}
+
+/* Full-viewport click-catcher, same trick ThemePicker uses. */
+.settings-popout__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+  background: transparent;
+}
+
+.settings-popout__panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  width: 300px;
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 12px;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  color: var(--color-text);
+}
+
+.settings-popout__header {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.settings-popout__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.settings-popout__row--stack {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.settings-popout__label {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.settings-popout__value {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.settings-popout__inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-popout__tier {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--color-bg-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+.settings-popout__tier--admin {
+  background: var(--color-primary-bg);
+  color: var(--color-on-primary-bg);
+  border-color: var(--color-primary);
+}
+
+.settings-popout__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.85rem;
+  padding: 5px 8px;
+  border-radius: 7px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+.settings-popout__input:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-bg);
+}
+
+.settings-popout__btn {
+  font-size: 0.78rem;
+  padding: 4px 10px;
+  border-radius: 7px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+.settings-popout__btn:hover:not(:disabled) {
+  background: var(--color-bg-alt);
+}
+.settings-popout__btn--primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+.settings-popout__btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+.settings-popout__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Content pill — a chunked "volume slider": segments 1..maxLevel, everything
+ * up to and including the selected level reads as filled. */
+.settings-popout__pill {
+  display: flex;
+  gap: 3px;
+  width: 100%;
+}
+.settings-popout__seg {
+  flex: 1 1 0;
+  padding: 7px 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-alt);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+.settings-popout__seg:first-child {
+  border-radius: 8px 0 0 8px;
+}
+.settings-popout__seg:last-child {
+  border-radius: 0 8px 8px 0;
+}
+.settings-popout__seg--filled {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+.settings-popout__seg:disabled {
+  cursor: default;
+}
+
+.settings-popout__hint {
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: var(--color-text-tertiary);
+}
+
+.settings-popout__error {
+  font-size: 0.75rem;
+  color: var(--color-danger);
+}

--- a/task-ui-components/src/components/AppHeader.tsx
+++ b/task-ui-components/src/components/AppHeader.tsx
@@ -1,0 +1,76 @@
+/**
+ * AppHeader — the ecosystem-standard top bar for every hadoku.me app.
+ *
+ * Enforces the shared contract so child apps stop drifting:
+ *   [ title (left) ] ————— <space> ————— [ status? · ThemePicker · Settings gear ] (right)
+ *
+ * Everything BELOW the header is the app's own concern. The header only owns
+ * the title and the right-hand action bar. The settings gear (ConnectedSettings)
+ * is injected automatically and self-wires to the hadoku edge-router, so the
+ * minimal adoption is:
+ *
+ * @example
+ * ```tsx
+ * import { AppHeader, ConnectedThemePicker } from '@wolffm/task-ui-components'
+ * import { THEME_FAMILIES, THEME_ICON_MAP } from '@wolffm/themes'
+ * import '@wolffm/task-ui-components/app-header.css'
+ * import '@wolffm/task-ui-components/theme-picker.css'
+ *
+ * <AppHeader
+ *   title="Print Tool"
+ *   status={<ApiStatus status={apiStatus} />}
+ *   themePicker={
+ *     <ConnectedThemePicker
+ *       themeFamilies={THEME_FAMILIES}
+ *       currentTheme={theme}
+ *       onThemeChange={setTheme}
+ *       getThemeIcon={(t) => { const I = THEME_ICON_MAP[t]; return I ? <I /> : null }}
+ *     />
+ *   }
+ * />
+ * ```
+ */
+import React from 'react'
+import { ConnectedSettings, type ConnectedSettingsProps } from './ConnectedSettings'
+
+export interface AppHeaderProps {
+  /** Left-aligned header title. A string is wrapped in an <h1>; pass a node for
+   *  custom markup (e.g. a clickable title button). */
+  title: React.ReactNode
+  /** The theme control — pass a `<ConnectedThemePicker />`. */
+  themePicker?: React.ReactNode
+  /** Optional status/extra node shown left of the theme + settings controls
+   *  (e.g. an "API Online" indicator). Acceptable per the header contract. */
+  status?: React.ReactNode
+  /** Show the unified settings gear. Default true. */
+  showSettings?: boolean
+  /** Forwarded to ConnectedSettings (userType / name / onNameChange). Omit to
+   *  let it self-resolve identity via whoami(). */
+  settingsProps?: ConnectedSettingsProps
+  /** Extra class on the <header> root. */
+  className?: string
+}
+
+export function AppHeader({
+  title,
+  themePicker,
+  status,
+  showSettings = true,
+  settingsProps,
+  className = ''
+}: AppHeaderProps) {
+  return (
+    <header className={`app-header ${className}`.trim()}>
+      {typeof title === 'string' ? (
+        <h1 className="app-header__title">{title}</h1>
+      ) : (
+        <div className="app-header__title">{title}</div>
+      )}
+      <div className="app-header__actions">
+        {status}
+        {themePicker}
+        {showSettings && <ConnectedSettings {...settingsProps} />}
+      </div>
+    </header>
+  )
+}

--- a/task-ui-components/src/components/ConnectedSettings.tsx
+++ b/task-ui-components/src/components/ConnectedSettings.tsx
@@ -1,0 +1,354 @@
+/**
+ * ConnectedSettings — the unified per-user settings control for the hadoku
+ * ecosystem: a gear button that opens a popout housing everything that is a
+ * property of the PERSON (not the app):
+ *   - current access tier (read-only, friendly label)
+ *   - display name (inline edit → POST /session/name)
+ *   - global content-visibility level (tiered pill → PUT /prefs/api/v1/content-level)
+ *   - auth key swap (→ POST /session/create, reloads on success)
+ *
+ * "Connected" (parallel to ConnectedThemePicker): it self-wires to the
+ * hadoku.me edge-router via same-origin fetches (see lib/settingsClient), so
+ * dropping `<ConnectedSettings />` into any app under hadoku.me needs zero
+ * props. Identity is resolved via whoami() unless the host passes `userType` /
+ * `name` (avoids a redundant fetch when the app already knows).
+ *
+ * Mirrors ThemePicker's controlled-popout pattern: owns its own `open` state +
+ * a full-viewport overlay for click-outside dismiss. The content pill renders
+ * `maxLevel` segments (friend ⇒ 3, admin ⇒ 4) and is hidden for public callers.
+ * maxLevel comes from the server so the tier ceiling is never trusted from the
+ * client.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { SettingsIcon } from './ThemeIcons'
+import {
+  getContentLevel,
+  setContentLevel,
+  setDisplayName,
+  swapAuthKey,
+  whoami,
+  type ContentLevelState,
+  type Tier
+} from '../lib/settingsClient'
+import '../app-header.css'
+
+export interface ConnectedSettingsProps {
+  /** Caller's tier. Omit to self-resolve via whoami(). */
+  userType?: Tier
+  /** Display name. Omit to self-resolve via whoami(). */
+  name?: string | null
+  /** Notify the host (e.g. a "Signed in as …" label) of a rename. */
+  onNameChange?: (name: string | null) => void
+  /** Optional extra class on the root. */
+  className?: string
+}
+
+/** Rejection sink for fire-and-forget settings actions. The client helpers
+ *  already resolve to null on failure (state reflects it), so this only trips
+ *  on truly unexpected throws — log rather than swallow silently. */
+function reportErr(err: unknown) {
+  // task-ui-components v2 dropped its logger; keep the package dependency-free.
+  console.error('[ConnectedSettings] action failed', (err as Error)?.message ?? err)
+}
+
+const TIER_LABEL: Record<Tier, string> = {
+  admin: 'Administrator',
+  friend: 'Friend',
+  service: 'Service',
+  public: 'Guest'
+}
+
+export function ConnectedSettings({
+  userType: userTypeProp,
+  name: nameProp,
+  onNameChange,
+  className = ''
+}: ConnectedSettingsProps) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // Identity — from props if supplied, else resolved lazily via whoami().
+  const [userType, setUserType] = useState<Tier>(userTypeProp ?? 'public')
+  const [resolvedName, setResolvedName] = useState<string | null>(nameProp ?? null)
+  const identityLoaded = useRef(userTypeProp !== undefined)
+
+  // Name editing
+  const [nameDraft, setNameDraft] = useState(resolvedName ?? '')
+  const [editingName, setEditingName] = useState(false)
+  const [nameSaving, setNameSaving] = useState(false)
+  const [displayName, setLocalName] = useState<string | null>(resolvedName)
+
+  // Key swap
+  const [showKeyInput, setShowKeyInput] = useState(false)
+  const [keyDraft, setKeyDraft] = useState('')
+  const [keySwapping, setKeySwapping] = useState(false)
+  const [keyError, setKeyError] = useState<string | null>(null)
+
+  // Content level
+  const [content, setContent] = useState<ContentLevelState | null>(null)
+  const [levelSaving, setLevelSaving] = useState(false)
+  const contentLoaded = useRef(false)
+
+  const showContentPill = userType === 'admin' || userType === 'friend' || userType === 'service'
+
+  // Keep local identity in sync when the host controls it via props.
+  useEffect(() => {
+    if (userTypeProp !== undefined) setUserType(userTypeProp)
+  }, [userTypeProp])
+  useEffect(() => {
+    if (nameProp !== undefined) {
+      setResolvedName(nameProp)
+      setLocalName(nameProp)
+      setNameDraft(nameProp ?? '')
+    }
+  }, [nameProp])
+
+  // Lazy-resolve identity the first time the popout opens (only if the host
+  // did not supply userType — otherwise props are the source of truth).
+  useEffect(() => {
+    if (!open || identityLoaded.current) return
+    identityLoaded.current = true
+    whoami()
+      .then(id => {
+        setUserType(id.userType)
+        setResolvedName(id.name)
+        setLocalName(id.name)
+        setNameDraft(id.name ?? '')
+      })
+      .catch(reportErr)
+  }, [open])
+
+  // Lazy-load the content level the first time the popout opens.
+  useEffect(() => {
+    if (!open || contentLoaded.current || !showContentPill) return
+    contentLoaded.current = true
+    getContentLevel()
+      .then(state => {
+        if (state) setContent(state)
+      })
+      .catch(reportErr)
+  }, [open, showContentPill])
+
+  // Escape closes.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+
+  const saveName = useCallback(async () => {
+    const trimmed = nameDraft.trim()
+    if (!trimmed || trimmed === displayName) {
+      setEditingName(false)
+      return
+    }
+    setNameSaving(true)
+    const stored = await setDisplayName(trimmed)
+    setNameSaving(false)
+    if (stored !== null) {
+      setLocalName(stored)
+      setNameDraft(stored)
+      onNameChange?.(stored)
+    }
+    setEditingName(false)
+  }, [nameDraft, displayName, onNameChange])
+
+  const pickLevel = useCallback(
+    async (level: number) => {
+      if (!content || level === content.level || levelSaving) return
+      const prev = content
+      setContent({ ...content, level }) // optimistic
+      setLevelSaving(true)
+      const result = await setContentLevel(level)
+      setLevelSaving(false)
+      setContent(result ?? prev) // adopt server truth, or revert
+    },
+    [content, levelSaving]
+  )
+
+  const doKeySwap = useCallback(async () => {
+    const key = keyDraft.trim()
+    if (!key) return
+    setKeySwapping(true)
+    setKeyError(null)
+    const result = await swapAuthKey(key)
+    if (!result) {
+      setKeySwapping(false)
+      setKeyError('That key was not accepted.')
+      return
+    }
+    // New session established — reload so every surface re-reads identity.
+    window.location.reload()
+  }, [keyDraft])
+
+  return (
+    <div className={`settings-popout ${className}`.trim()} ref={rootRef}>
+      <button
+        type="button"
+        className="settings-toggle-btn"
+        aria-label="User settings"
+        aria-expanded={open}
+        onClick={() => setOpen(v => !v)}
+      >
+        <SettingsIcon />
+      </button>
+
+      {open && <div className="settings-popout__overlay" onClick={() => setOpen(false)} />}
+
+      {open && (
+        <div className="settings-popout__panel" role="dialog" aria-label="User settings">
+          <div className="settings-popout__header">Settings</div>
+
+          {/* Access tier */}
+          <section className="settings-popout__row">
+            <span className="settings-popout__label">Access tier</span>
+            <span className={`settings-popout__tier settings-popout__tier--${userType}`}>
+              {TIER_LABEL[userType]}
+            </span>
+          </section>
+
+          {/* Display name */}
+          <section className="settings-popout__row">
+            <span className="settings-popout__label">Display name</span>
+            {editingName ? (
+              <span className="settings-popout__inline">
+                <input
+                  className="settings-popout__input"
+                  value={nameDraft}
+                  maxLength={64}
+                  autoFocus
+                  disabled={nameSaving}
+                  onChange={e => setNameDraft(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      saveName().catch(reportErr)
+                    }
+                    if (e.key === 'Escape') {
+                      setEditingName(false)
+                      setNameDraft(displayName ?? '')
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className="settings-popout__btn settings-popout__btn--primary"
+                  disabled={nameSaving}
+                  onClick={() => {
+                    saveName().catch(reportErr)
+                  }}
+                >
+                  {nameSaving ? '…' : 'Save'}
+                </button>
+              </span>
+            ) : (
+              <span className="settings-popout__inline">
+                <span className="settings-popout__value">{displayName || 'Unnamed'}</span>
+                <button
+                  type="button"
+                  className="settings-popout__btn"
+                  onClick={() => {
+                    setNameDraft(displayName ?? '')
+                    setEditingName(true)
+                  }}
+                >
+                  Edit
+                </button>
+              </span>
+            )}
+          </section>
+
+          {/* Content visibility level */}
+          {showContentPill && (
+            <section className="settings-popout__row settings-popout__row--stack">
+              <span className="settings-popout__label">Content visibility</span>
+              {content ? (
+                <>
+                  <div
+                    className="settings-popout__pill"
+                    role="radiogroup"
+                    aria-label="Content visibility level"
+                  >
+                    {Array.from({ length: content.maxLevel }, (_, i) => i + 1).map(lvl => (
+                      <button
+                        key={lvl}
+                        type="button"
+                        role="radio"
+                        aria-checked={lvl === content.level}
+                        aria-label={`Level ${lvl}`}
+                        className={`settings-popout__seg${
+                          lvl <= content.level ? ' settings-popout__seg--filled' : ''
+                        }`}
+                        disabled={levelSaving}
+                        onClick={() => {
+                          pickLevel(lvl).catch(reportErr)
+                        }}
+                      >
+                        {lvl}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="settings-popout__hint">
+                    Higher levels reveal more mature content across apps. Level 1 is
+                    safe-for-everyone.
+                  </span>
+                </>
+              ) : (
+                <span className="settings-popout__hint">Loading…</span>
+              )}
+            </section>
+          )}
+
+          {/* Auth key swap */}
+          <section className="settings-popout__row settings-popout__row--stack">
+            <span className="settings-popout__label">Access key</span>
+            {showKeyInput ? (
+              <span className="settings-popout__inline">
+                <input
+                  className="settings-popout__input"
+                  type="password"
+                  placeholder="New access key"
+                  value={keyDraft}
+                  autoFocus
+                  disabled={keySwapping}
+                  onChange={e => setKeyDraft(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      doKeySwap().catch(reportErr)
+                    }
+                    if (e.key === 'Escape') {
+                      setShowKeyInput(false)
+                      setKeyDraft('')
+                      setKeyError(null)
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className="settings-popout__btn settings-popout__btn--primary"
+                  disabled={keySwapping}
+                  onClick={() => {
+                    doKeySwap().catch(reportErr)
+                  }}
+                >
+                  {keySwapping ? '…' : 'Switch'}
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="settings-popout__btn"
+                onClick={() => setShowKeyInput(true)}
+              >
+                Change key…
+              </button>
+            )}
+            {keyError && <span className="settings-popout__error">{keyError}</span>}
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/task-ui-components/src/index.ts
+++ b/task-ui-components/src/index.ts
@@ -7,6 +7,8 @@
 // Main components
 export { ThemePicker } from './components/ThemePicker'
 export { ConnectedThemePicker } from './components/ConnectedThemePicker'
+export { AppHeader } from './components/AppHeader'
+export { ConnectedSettings } from './components/ConnectedSettings'
 export { Toast } from './components/Toast'
 export { Toaster } from './components/Toaster'
 export { Modal } from './components/Modal'
@@ -52,6 +54,9 @@ export {
 // Types
 export type { ThemeName, ThemeFamily, ThemePickerProps, DropdownPlacement } from './types'
 export type { ConnectedThemePickerProps } from './components/ConnectedThemePicker'
+export type { AppHeaderProps } from './components/AppHeader'
+export type { ConnectedSettingsProps } from './components/ConnectedSettings'
+export type { ContentLevelState, Identity, KeySwapResult, Tier } from './lib/settingsClient'
 export type { ToastProps } from './components/Toast'
 export type { ToasterProps, ToastState } from './components/Toaster'
 export type { UseToastReturn } from './hooks/useToast'

--- a/task-ui-components/src/lib/settingsClient.ts
+++ b/task-ui-components/src/lib/settingsClient.ts
@@ -1,0 +1,164 @@
+/**
+ * Client for the unified user-settings modal (ConnectedSettings).
+ *
+ * Three concerns, all cookie-authed against the hadoku.me edge-router, which
+ * resolves the `hadoku_session` cookie / `X-Session-Id` header → X-User-Key +
+ * X-User-Id for the backend:
+ *   - display name  → POST /session/name                   (edge-router, self rename)
+ *   - content level → GET/PUT /prefs/api/v1/content-level  (prefs-api)
+ *   - auth key swap → POST /session/create                 (edge-router, new session)
+ *
+ * These are same-origin relative paths, so ConnectedSettings is portable to any
+ * app served under hadoku.me with zero wiring. Off-origin (e.g. a Storybook or
+ * a non-hadoku host) every call resolves to null and the UI degrades to a
+ * read-only shell — it never throws.
+ *
+ * The raw key is never held in the browser (the auth page deliberately drops
+ * it), so name + content-level changes go through session identity, not a key
+ * header. Only an explicit key SWAP re-presents a key — the new one the user
+ * types.
+ */
+
+/** Edge-router / prefs-api endpoints (same-origin relative). */
+const CONTENT_LEVEL_PATH = '/prefs/api/v1/content-level'
+const SESSION_NAME = '/session/name'
+const SESSION_CREATE = '/session/create'
+const SESSION_WHOAMI = '/session/whoami'
+
+// Hard timeout on every settings request. Without it, a request throttled by
+// the browser (e.g. the tab going to the background) leaves the caller's
+// "saving" flag stuck true — which disabled the content-level pills until the
+// tab regained focus. AbortSignal.timeout guarantees the promise settles.
+const REQUEST_TIMEOUT_MS = 8000
+
+/** Session-id header the same way whoami() sends it (cookie is the fallback). */
+function sessionHeaders(extra?: Record<string, string>): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', ...extra }
+  const sid = typeof window !== 'undefined' ? localStorage.getItem('hadoku_session_id') : null
+  if (sid) headers['X-Session-Id'] = sid
+  return headers
+}
+
+export interface ContentLevelState {
+  /** Current global content-visibility level (1 = safest default). */
+  level: number
+  /** Highest level this caller's tier may select (friend=3, admin=4). */
+  maxLevel: number
+}
+
+/** GET the caller's current content level + tier ceiling. null on error. */
+export async function getContentLevel(): Promise<ContentLevelState | null> {
+  try {
+    const res = await fetch(CONTENT_LEVEL_PATH, {
+      credentials: 'same-origin',
+      headers: sessionHeaders(),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) return null
+    return (await res.json()) as ContentLevelState
+  } catch {
+    return null
+  }
+}
+
+/** PUT a new content level. Server clamps to the tier ceiling → 400 if out of
+ *  range. Returns the stored state on success, null on any failure. */
+export async function setContentLevel(level: number): Promise<ContentLevelState | null> {
+  try {
+    const res = await fetch(CONTENT_LEVEL_PATH, {
+      method: 'PUT',
+      credentials: 'same-origin',
+      headers: sessionHeaders(),
+      body: JSON.stringify({ level }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) return null
+    return (await res.json()) as ContentLevelState
+  } catch {
+    return null
+  }
+}
+
+/** POST a new display name for the signed-in user. Returns the stored name
+ *  (may differ from the request for wp-* protected keys) or null on failure. */
+export async function setDisplayName(name: string): Promise<string | null> {
+  try {
+    const res = await fetch(SESSION_NAME, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: sessionHeaders(),
+      body: JSON.stringify({ name }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { ok: boolean; name: string | null }
+    return body.name
+  } catch {
+    return null
+  }
+}
+
+export type Tier = 'admin' | 'friend' | 'service' | 'public'
+
+export interface Identity {
+  userType: Tier
+  name: string | null
+}
+
+/**
+ * Resolve the signed-in caller's tier + display name from the edge-router.
+ * Returns { userType: 'public', name: null } for anonymous / off-origin / any
+ * failure — never throws, so ConnectedSettings can render unconditionally.
+ */
+export async function whoami(): Promise<Identity> {
+  if (typeof window === 'undefined') return { userType: 'public', name: null }
+  try {
+    const res = await fetch(SESSION_WHOAMI, {
+      credentials: 'same-origin',
+      headers: sessionHeaders(),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) return { userType: 'public', name: null }
+    const body = (await res.json()) as { valid?: boolean; userType?: Tier; name?: string | null }
+    if (!body.valid) return { userType: 'public', name: null }
+    return { userType: body.userType ?? 'public', name: body.name ?? null }
+  } catch {
+    return { userType: 'public', name: null }
+  }
+}
+
+export interface KeySwapResult {
+  userType: Tier
+  name: string | null
+}
+
+/**
+ * Swap the active auth key. POSTs the new key to /session/create, which mints
+ * a FRESH session (new sessionId + cookie) — so on success we rewrite the
+ * localStorage session mirror the rest of the app reads. Caller is expected to
+ * reload afterwards so every mounted surface re-reads identity. Returns the new
+ * tier on success, null on an invalid key / failure.
+ */
+export async function swapAuthKey(newKey: string): Promise<KeySwapResult | null> {
+  try {
+    const res = await fetch(SESSION_CREATE, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', 'X-User-Key': newKey },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as {
+      valid: boolean
+      sessionId?: string
+      userType: Tier
+      name: string | null
+    }
+    if (!body.valid || !body.sessionId) return null
+    localStorage.setItem('hadoku_session_id', body.sessionId)
+    localStorage.setItem('hadoku_user_type', body.userType)
+    return { userType: body.userType, name: body.name }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Why

Every hadoku.me child app is mounted with `showHeader={false}`, so each app draws **its own** header inside its `mount()`. Result: 14 hand-rolled headers that have drifted — theme pickers left-aligned (contact), stray nav tabs in the bar (jobplatform), no color system at all (pygmalion/promptsmith). A template can't enforce a contract; a shared importable component can.

This is **Phase 1** of the ecosystem header-unification effort: ship the shared piece, then adopt it everywhere.

## The contract

```
[ title (left) ] ————— <space> ————— [ status? · ThemePicker · Settings gear ] (right)
```

Everything **below** the header stays the app's own concern.

## What's here

- **`AppHeader`** — enforces the layout above. Apps pass their existing `ConnectedThemePicker` (theme state stays app-side, no new deps); the settings gear is injected automatically. Optional `status` slot for things like an "API Online" indicator.
- **`ConnectedSettings`** — the unified per-user settings popout (access tier · display name · global content-visibility level · auth-key swap). Ported from hadoku-site's `SettingsPopout` and made **self-wiring**: resolves identity via `/session/whoami` and hits the edge-router `/session/*` + prefs-api `/prefs/api/v1/content-level` routes over same-origin fetches. Off `hadoku.me` every call resolves to a safe default and it renders a read-only shell — never throws.
- **`app-header.css`** — semantic `@wolffm/themes` tokens only (passes the theme-token validator), exported as `./app-header.css`, wired into `copy-css`.
- **eslint**: registered the `AbortSignal`/`AbortController` browser globals (previously missing).

Minimal adoption:

```tsx
import { AppHeader, ConnectedThemePicker } from '@wolffm/task-ui-components'
import '@wolffm/task-ui-components/app-header.css'

<AppHeader
  title="Print Tool"
  status={<ApiStatus status={apiStatus} />}
  themePicker={<ConnectedThemePicker {...themeProps} />}
/>
```

## Notes

- Minor bump to **2.1.0** — additive, every consumer is on `^2.0.x` today so the upgrade is clean.
- Typecheck, eslint, stylelint, and the full `@wolffm/themes` token validation all pass in pre-commit.
- Follow-up PRs adopt `AppHeader` in printTool (the reference), then the other React apps; the vanilla Python apps get spec issues.