### PR TITLE
text on modals is not highlightable

### DIFF
--- a/src/hooks/useDragAndDrop/index.ts
+++ b/src/hooks/useDragAndDrop/index.ts
@@ -208,7 +208,7 @@ export function useDragAndDrop({
       // Do not start when clicking inside a task item or direct interactive controls
       // Allow starting inside tag columns (empty areas) so box-select works there.
       const interactiveSelector =
-        '.task-app__item, .task-app__controls, button, input, textarea, .task-app__item-actions'
+        '.task-app__item, .task-app__controls, button, input, textarea, .task-app__item-actions, .modal-overlay'
       if (tg.closest && tg.closest(interactiveSelector)) {
         return
       }


### PR DESCRIPTION
Opened by hadoku-task-automation for task `01KYH16ZNPN1TW44TAGHBTYT4W`.

**Task as filed:** text on modals is not highlightable

Nobody has reviewed this. The repo's own required checks are the gate — merge it if they are green and the diff reads right.

### Preflight
- diff_non_empty: 1 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/01kyh16znpn1
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 8fe6101b → taskauto/01kyh16znpn1