### PR TITLE
ui inside edit boards looks ugly

### DIFF
--- a/src/components/modals/EditBoardsModal.tsx
+++ b/src/components/modals/EditBoardsModal.tsx
@@ -209,6 +209,8 @@ export function EditBoardsModal({
         <li
           className={[
             'edit-boards__row',
+            'hdk-advanced-surface',
+            'hdk-advanced-surface--shift',
             b.id === currentBoardId ? 'is-current' : '',
             draggable ? 'is-draggable' : '',
             dragId === b.id ? 'is-dragging' : '',

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -270,6 +270,10 @@
   color: var(--color-text);
 }
 
+.edit-boards__name-input {
+  font-weight: var(--font-weight-semibold);
+}
+
 .edit-boards__search {
   width: 100%;
   margin-bottom: var(--hdk-space-md);
@@ -304,10 +308,15 @@
   display: flex;
   align-items: center;
   gap: var(--hdk-space-sm);
-  padding: var(--hdk-space-sm);
-  border: 1px solid var(--color-border);
-  border-radius: var(--hdk-radius-sm);
+  padding: var(--hdk-space-md) var(--hdk-space-lg);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--hdk-radius-lg);
   background: var(--color-bg-card);
+  box-shadow: var(--hdk-shadow-sm);
+  transition: box-shadow var(--transition-smooth);
+}
+.edit-boards__row:hover {
+  box-shadow: var(--hdk-shadow-md);
 }
 .edit-boards__row.is-current {
   border-color: var(--color-primary);


### PR DESCRIPTION
Opened by hadoku-task-automation for task `01KYH1708RQEWZ74P4PTTCEDY3`.

**Task as filed:** ui inside edit boards looks ugly

Nobody has reviewed this. The repo's own required checks are the gate — merge it if they are green and the diff reads right.

### Preflight
- diff_non_empty: 2 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/01kyh1708rqe
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 16c44412 → taskauto/01kyh1708rqe