### PR TITLE
calendar view, the 'today' button reads as a label not a button

### DIFF
--- a/src/components/calendar/CalendarDayView.tsx
+++ b/src/components/calendar/CalendarDayView.tsx
@@ -170,7 +170,7 @@ export function CalendarDayView({
           </span>
           {!isToday && (
             <button className="calendar-today-btn" onClick={handleToday}>
-              Today
+              ⟲ Today
             </button>
           )}
         </div>

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -55,23 +55,27 @@
 
 .calendar-date-label--today {
   color: var(--color-text);
+  background: var(--color-primary-bg);
+  padding: 2px var(--hdk-space-sm);
+  border-radius: var(--hdk-radius-sm);
 }
 
 .calendar-today-btn {
   background: transparent;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-primary);
   border-radius: 999px;
   padding: var(--hdk-space-xs) var(--hdk-space-md);
   font-size: var(--hdk-text-sm);
-  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
   cursor: pointer;
   transition: all var(--transition-fast);
 }
 
 .calendar-today-btn:hover {
-  background: var(--color-primary-hover);
+  background: var(--color-primary);
   border-color: var(--color-primary);
-  color: var(--color-primary);
+  color: var(--color-on-primary);
 }
 
 /* New-task button — sits at the end of the header */


### PR DESCRIPTION
Opened by hadoku-task-automation for task `01KYH170VFCSG3S27TXSJDW7WV`.

**Task as filed:** bug-calendar view, the 'today' button reads as a label not a button

Nobody has reviewed this. The repo's own required checks are the gate — merge it if they are green and the diff reads right.

### Preflight
- diff_non_empty: 2 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/01kyh170vfcs
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 8b64bf1d → taskauto/01kyh170vfcs