### PR TITLE
all automation tasks are showing '1 open question' even though mo…

### DIFF
--- a/e2e/plan-review.spec.ts
+++ b/e2e/plan-review.spec.ts
@@ -134,6 +134,16 @@ test.describe('plan review', () => {
       notes: '## Questions\n\nNo open questions.\n'
     })
     await createTask(request, boardId, { id: `${boardId}-c`, title: 'Nothing written', notes: '' })
+    await createTask(request, boardId, {
+      id: `${boardId}-d`,
+      title: 'Sentinel wrapped in emphasis',
+      notes: '## Questions\n\n_No open questions._\n'
+    })
+    await createTask(request, boardId, {
+      id: `${boardId}-e`,
+      title: 'Sentinel as a bullet',
+      notes: '## Questions\n\n- No open questions.\n'
+    })
     await signIn(page)
     await openBoard(page, boardId)
   })
@@ -145,6 +155,12 @@ test.describe('plan review', () => {
     await expect(card(page, 'Nothing to answer').locator('.task-app__item-questions')).toHaveCount(
       0
     )
+    await expect(
+      card(page, 'Sentinel wrapped in emphasis').locator('.task-app__item-questions')
+    ).toHaveCount(0)
+    await expect(
+      card(page, 'Sentinel as a bullet').locator('.task-app__item-questions')
+    ).toHaveCount(0)
   })
 
   test('the plan opens outside the card, at a real size', async ({ page }) => {

--- a/src/domain/planNotes.ts
+++ b/src/domain/planNotes.ts
@@ -47,6 +47,22 @@ function isQuestionsHeading(title: string): boolean {
 }
 
 /**
+ * Strip a leading list marker and surrounding `*`/`_` emphasis so the "no open
+ * questions" sentinel is recognized regardless of the markdown an agent wraps
+ * it in — e.g. `_No open questions._` or `- No open questions.`. Mirrors the
+ * tolerant-heading pattern above: written each pass by an agent, so a strict
+ * match would silently miscount.
+ */
+function stripSentinelMarkup(text: string): string {
+  let s = text.trim()
+  const listMatch = LIST_ITEM.exec(s)
+  if (listMatch) s = s.slice(listMatch[0].length).trim()
+  const emphasisMatch = /^(\*{1,3}|_{1,3})([\s\S]*)\1$/.exec(s)
+  if (emphasisMatch) s = emphasisMatch[2].trim()
+  return s
+}
+
+/**
  * Split a plan into its `## ` sections. Content before the first heading becomes
  * a leading section with an empty title. Never throws, never drops input.
  */
@@ -124,7 +140,7 @@ export function openQuestionCount(sections: PlanSection[]): number {
   if (!section) return 0
 
   const body = section.body.trim()
-  if (!body || NO_QUESTIONS.test(body)) return 0
+  if (!body || NO_QUESTIONS.test(stripSentinelMarkup(body))) return 0
 
   const items = listItems(body)
   if (!body.includes('?')) return items.length


### PR DESCRIPTION
Opened by hadoku-task-automation for task `MS3GNQCOHB3L8C1QVICSMM8U70`.

**Task as filed:** all automation tasks are showing '1 open question' even though most of them have 'no open questions'

Nobody has reviewed this. The repo's own required checks are the gate — merge it if they are green and the diff reads right.

### Preflight
- diff_non_empty: 2 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/ms3gnqcohb3l
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 94a1225a → taskauto/ms3gnqcohb3l