### PR TITLE
buggy interating with dragging while in edit boards view. i notic…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -159,20 +159,22 @@ export default function App(props: TaskAppProps = {}) {
     shareApi
   } = useTasks({ userType, sessionId: effectiveSessionId, onSyncError: reportSyncError })
 
+  // Modal state hook
+  const modals = useModalState()
+
   // Drag and drop hook
   const dragAndDrop = useDragAndDrop({
     tasks,
     onTaskUpdate: updateTaskTags,
     onBulkUpdate: bulkUpdateTaskTags,
     // Board-only interaction; disabling in calendar keeps text selectable/copyable.
-    enabled: currentView === 'board'
+    // Also disabled while any modal is open, so drag-to-select never engages
+    // underneath an open panel (e.g. Edit Boards).
+    enabled: currentView === 'board' && !modals.isAnyModalOpen
   })
 
   // Sort hook
   const sortHook = useTaskSort()
-
-  // Modal state hook
-  const modals = useModalState()
 
   // Pull-to-refresh — only inside the mobile WebView; desktop pull is meaningless.
   // Reuses the same handler the in-app refresh button does (initialLoad → syncFromApi).

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -56,6 +56,11 @@ export interface UseModalStateReturn {
   setValidationError: (error: string | null) => void
   pendingTaskOperation: PendingTaskOperation | null
   setPendingTaskOperation: (op: PendingTaskOperation | null) => void
+
+  // True while any modal/dialog/context-menu is open — used to suppress
+  // board-only interactions (e.g. marquee drag-to-select) that would
+  // otherwise fire underneath the open panel.
+  isAnyModalOpen: boolean
 }
 
 /**
@@ -108,6 +113,18 @@ export function useModalState(): UseModalStateReturn {
     null
   )
 
+  const isAnyModalOpen = Boolean(
+    showNewBoardDialog ||
+      showEditBoardsDialog ||
+      showShareDialog ||
+      showNewTagDialog ||
+      showSettingsModal ||
+      editTagModal ||
+      confirmClearTag ||
+      boardContextMenu ||
+      tagContextMenu
+  )
+
   return {
     confirmClearTag,
     setConfirmClearTag,
@@ -134,6 +151,7 @@ export function useModalState(): UseModalStateReturn {
     validationError,
     setValidationError,
     pendingTaskOperation,
-    setPendingTaskOperation
+    setPendingTaskOperation,
+    isAnyModalOpen
   }
 }


### PR DESCRIPTION
Opened by hadoku-task-automation for task `MS3GT4QMQ0XISM3R1IZFF34BU2`.

**Task as filed:** buggy interating with dragging while in edit boards view. i notice the box drag mode activate behind the popout panel. the 'drag to select' tasks should not activate while i'm looking at edit boards

Nobody has reviewed this. The repo's own required checks are the gate — merge it if they are green and the diff reads right.

### Preflight
- diff_non_empty: 2 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/ms3gt4qmq0xi
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 01ffdb05 → taskauto/ms3gt4qmq0xi