### PR TITLE
test(ci): docs-only probe for the PR-gate invariant

### DIFF
--- a/docs/pr-gate-probe.md
+++ b/docs/pr-gate-probe.md
@@ -1,0 +1,17 @@
+# PR-gate probe
+
+Temporary. This file exists to test one thing, and it is not "is CI green".
+
+The invariant (tenhands `docs/hadoku-task-automation/pr-gate-invariant.md`) is:
+
+> For every pull request a repo can receive, at least one **required** status
+> check must report a result.
+
+The PR that added `ci.yml` could only ever prove the **run** path — its own diff
+touched `.github/workflows/ci.yml`, which all three scope lists match, so all
+three jobs ran in full. The **skip** path needs a PR that touches nothing any
+job cares about, opened against a `main` that already carries the workflow.
+
+This file is that PR. Expected: `typecheck`, `lint` and `worker-tests` all
+report green in seconds, with their scope steps saying they found nothing to do.
+Deleted immediately after.


### PR DESCRIPTION
Acceptance test for the invariant, not a change to keep. Touches one docs file and nothing else, so `typecheck`, `lint` and `worker-tests` should all report **green in seconds without installing anything**. Closed as soon as that is observed.