### PR TITLE
perf(settings): take the content level off whoami, dropping the extra request

### DIFF
--- a/e2e/settings-prefetch.spec.ts
+++ b/e2e/settings-prefetch.spec.ts
@@ -137,6 +137,53 @@ test.describe('settings prefetch', () => {
     expect(counts.whoami, 'whoami resolved more than once per page load').toBeLessThanOrEqual(1)
   })
 
+  test('takes the content level off whoami when edge-router reports it', async ({ page }) => {
+    // The current edge-router carries contentLevel/maxContentLevel on whoami —
+    // authGate already resolved the level to stamp X-Hadoku-Content-Level, so
+    // reporting it is free and the proxied prefs-api round trip disappears.
+    const counts = countRequests(page)
+    await stubBoot(page)
+    await signedIn(page)
+    await page.route(`**${WHOAMI_PATH}`, route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...IDENTITY, contentLevel: 3, maxContentLevel: 4 })
+      })
+    )
+
+    await bootApp(page)
+    await page.getByRole('button', { name: 'User settings' }).click()
+    await page.waitForSelector('.settings-popout__panel', { state: 'visible', timeout: 5000 })
+
+    // Rendered from the whoami body — note maxLevel 4, which the CONTENT stub
+    // does not serve, so this can only have come from whoami.
+    await expect(page.locator('.settings-popout__seg')).toHaveCount(4)
+    await expect(page.locator('.settings-popout__seg--filled')).toHaveCount(3)
+
+    await page.waitForTimeout(1500)
+    expect(counts.content, 'fetched content-level that whoami already carried').toBe(0)
+  })
+
+  test('falls back to the GET when whoami does not carry the level', async ({ page }) => {
+    // An older edge-router, or a host not behind one at all. The popout must
+    // still fill in — the fallback is what keeps this bundle deployable ahead
+    // of the edge change, and usable from Capacitor/Storybook.
+    const counts = countRequests(page)
+    await stubBoot(page) // IDENTITY has no contentLevel fields
+    await signedIn(page)
+    await bootApp(page)
+
+    await expect
+      .poll(() => counts.content, { timeout: 10000, message: 'fallback GET never issued' })
+      .toBe(1)
+
+    await page.getByRole('button', { name: 'User settings' }).click()
+    await page.waitForSelector('.settings-popout__panel', { state: 'visible', timeout: 5000 })
+    await expect(page.locator('.settings-popout__seg')).toHaveCount(CONTENT.maxLevel)
+    await expect(page.locator('.settings-popout__seg--filled')).toHaveCount(CONTENT.level)
+  })
+
   test('reuses the shell’s boot whoami instead of issuing its own', async ({ page }) => {
     const counts = countRequests(page)
     await stubBoot(page)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/task",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Minimalist, portable task manager - embeddable micro-frontend with framework-agnostic API handlers",
   "type": "module",
   "repository": {

--- a/task-ui-components/package.json
+++ b/task-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolffm/task-ui-components",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Reusable UI components with Bento grid and metallic gradient support",
   "type": "module",
   "main": "dist/index.js",

--- a/task-ui-components/src/lib/settingsClient.ts
+++ b/task-ui-components/src/lib/settingsClient.ts
@@ -44,11 +44,21 @@ const SESSION_WHOAMI = '/session/whoami'
  */
 const WHOAMI_GLOBAL = '__hadokuWhoami'
 
-/** Raw whoami body, as both mf-loader and this module see it off the wire. */
+/**
+ * Raw whoami body, as both mf-loader and this module see it off the wire.
+ *
+ * `contentLevel` / `maxContentLevel` are OPTIONAL because the shape is
+ * versioned by whatever edge-router is deployed, not by this bundle. They
+ * arrive from edge-router ≥ the 2026-08-07 change, which reports the level
+ * `authGate` had already resolved to stamp X-Hadoku-Content-Level. When they
+ * are absent we fall back to the standalone GET — see resolveSettings.
+ */
 interface WhoamiBody {
   valid?: boolean
   userType?: Tier
   name?: string | null
+  contentLevel?: number
+  maxContentLevel?: number
 }
 
 // Hard timeout on every settings request. Without it, a request throttled by
@@ -142,31 +152,37 @@ export interface Identity {
 }
 
 /**
+ * The page's one whoami body, resolved at most once no matter how many callers.
+ *
+ * Under the hadoku.me shell this costs NO request: mf-loader kicks whoami in
+ * parallel with the micro-frontend's module import and parks the promise on
+ * WHOAMI_GLOBAL for exactly this reason (@wolffm/prefs-client reads the same
+ * key). Elsewhere — standalone vite, Capacitor, Storybook — we fetch once and
+ * publish under the same key so the next reader is free too.
+ *
+ * Resolves to null rather than throwing on any failure.
+ */
+function sharedWhoami(): Promise<WhoamiBody | null> {
+  const g = globalThis as { [WHOAMI_GLOBAL]?: Promise<WhoamiBody | null> }
+  g[WHOAMI_GLOBAL] ??= fetch(SESSION_WHOAMI, {
+    credentials: 'same-origin',
+    headers: sessionHeaders(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  })
+    .then(res => (res.ok ? (res.json() as Promise<WhoamiBody>) : null))
+    .catch(() => null)
+  return g[WHOAMI_GLOBAL]
+}
+
+/**
  * Resolve the signed-in caller's tier + display name from the edge-router.
  * Returns { userType: 'public', name: null } for anonymous / off-origin / any
  * failure — never throws, so ConnectedSettings can render unconditionally.
- *
- * Costs no request under the hadoku.me shell: it awaits the boot whoami the
- * loader already has in flight (see WHOAMI_GLOBAL). Elsewhere it fetches once
- * and publishes the promise, so this is at most one whoami per page load no
- * matter how many callers there are.
  */
 export async function whoami(): Promise<Identity> {
   if (typeof window === 'undefined') return { userType: 'public', name: null }
-  const g = globalThis as { [WHOAMI_GLOBAL]?: Promise<WhoamiBody | null> }
-  let shared = g[WHOAMI_GLOBAL]
-  if (!shared) {
-    shared = fetch(SESSION_WHOAMI, {
-      credentials: 'same-origin',
-      headers: sessionHeaders(),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
-    })
-      .then(res => (res.ok ? (res.json() as Promise<WhoamiBody>) : null))
-      .catch(() => null)
-    g[WHOAMI_GLOBAL] = shared
-  }
   try {
-    const body = await shared
+    const body = await sharedWhoami()
     if (!body?.valid) return { userType: 'public', name: null }
     return { userType: body.userType ?? 'public', name: body.name ?? null }
   } catch {
@@ -242,9 +258,13 @@ let snapshot: Promise<SettingsSnapshot> | null = null
  * the app's own boot traffic and the click costs nothing.
  *
  * Idempotent and shared: every caller after the first gets the same promise, so
- * N mounted consumers still produce at most one whoami and one content-level
- * for the whole page. Mutations below write through to it rather than
- * invalidating, so a remount never shows a value the user just changed.
+ * N mounted consumers still produce at most one whoami for the whole page.
+ * Mutations below write through to it rather than invalidating, so a remount
+ * never shows a value the user just changed.
+ *
+ * Against a current edge-router this issues NO requests of its own at all — the
+ * level rides on the whoami the shell already had in flight. See
+ * resolveSettings for the fallback when it doesn't.
  */
 export function prefetchSettings(hints: SettingsPrefetchHints = {}): Promise<SettingsSnapshot> {
   snapshot ??= resolveSettings(hints)
@@ -252,24 +272,61 @@ export function prefetchSettings(hints: SettingsPrefetchHints = {}): Promise<Set
 }
 
 async function resolveSettings(hints: SettingsPrefetchHints): Promise<SettingsSnapshot> {
+  // The whoami body, not just the adapted identity — edge-router carries the
+  // content level on it (see below), and reading the raw body is how we get at
+  // it without a second request.
+  //
+  // Skipped entirely when the host supplied identity: that prop exists for apps
+  // that CANNOT reach /session/whoami (conjure sits behind a path-prefixed shim
+  // where it 404s), so asking anyway would spend a request to learn nothing.
+  const selfResolving = hints.userType === undefined && typeof window !== 'undefined'
+  const bodyPromise = selfResolving ? sharedWhoami() : Promise.resolve(null)
+
   const identityPromise: Promise<Identity> =
     hints.userType !== undefined
       ? Promise.resolve({ userType: hints.userType, name: hints.name ?? null })
       : whoami()
 
-  // Identity decides whether a content request is warranted at all — the pill
-  // is hidden for public callers, so fetching an anonymous visitor's level is a
-  // guaranteed-wasted request on every page view. Where we can tell up front
-  // that the caller is signed in, the two go out together instead; the cached
-  // `hadoku_user_type` is written by hadoku_site's loader before anything
-  // mounts, which covers the only case that would otherwise serialise two real
-  // round trips.
-  const contentPromise = looksSignedIn(hints.userType)
-    ? getContentLevel()
-    : identityPromise.then(id => (id.userType === 'public' ? null : getContentLevel()))
+  // PREFERRED PATH: take the level straight off whoami.
+  //
+  // edge-router's authGate has already resolved it (registry key → userId →
+  // prefs D1) to stamp X-Hadoku-Content-Level, so reporting it on whoami costs
+  // it nothing — and it saves us a proxied round trip to prefs-api that
+  // measured 132-420ms against prod. Better still, whoami is in flight before
+  // this bundle has even loaded, so the value is here the moment we ask.
+  //
+  // FALLBACK: the standalone GET, for any edge-router older than the
+  // 2026-08-07 change, and for callers not behind it at all (Capacitor,
+  // Storybook, a non-hadoku host). Gated on identity because the pill is
+  // hidden for public callers — fetching an anonymous visitor's level is a
+  // guaranteed-wasted request on every page view. `hadoku_user_type` is
+  // written by the loader before anything mounts, so where it already says
+  // "signed in" the fallback goes out concurrently rather than behind whoami.
+  const contentPromise = bodyPromise.then(body => {
+    const carried = contentFromWhoami(body)
+    if (carried) return carried
+    if (looksSignedIn(hints.userType)) return getContentLevel()
+    return identityPromise.then(id => (id.userType === 'public' ? null : getContentLevel()))
+  })
 
   const [identity, content] = await Promise.all([identityPromise, contentPromise])
   return { identity, content }
+}
+
+/**
+ * Adapt the content level off a whoami body, or null if that edge-router
+ * doesn't report it.
+ *
+ * Both fields are required, and both must be numbers: a body carrying a level
+ * without its ceiling would render a pill with zero segments — worse than the
+ * fallback fetch, because it looks like a working control that offers nothing.
+ */
+function contentFromWhoami(body: WhoamiBody | null): ContentLevelState | null {
+  if (!body?.valid) return null
+  const { contentLevel, maxContentLevel } = body
+  if (typeof contentLevel !== 'number' || typeof maxContentLevel !== 'number') return null
+  if (maxContentLevel < 1) return null
+  return { level: contentLevel, maxLevel: maxContentLevel }
 }
 
 /** Best-effort "is this caller signed in?" from state available synchronously. */


### PR DESCRIPTION
Consumer half of WolffM/hadoku_site#231. **Safe to merge in either order** — it falls back when the edge doesn't yet report the fields.

## What changed

`@wolffm/task-ui-components@4.1.1` moved the settings popout's data from gear-click to page load. This removes the second of its two requests outright.

`GET /prefs/api/v1/content-level` is a **proxied** round trip — edge-router → prefs-api worker → D1 — measuring 132–420ms TTFB against prod, versus 97–214ms for whoami, which terminates at the edge. Worse, it couldn't be *issued* until this bundle had downloaded, parsed and mounted, so in a prod trace it landed at `+1245ms` while whoami (issued by `mf-loader` before the dynamic `import()`) landed at `+250ms`.

edge-router's `authGate` had already resolved that exact value to stamp `X-Hadoku-Content-Level` and whoami discarded it. hadoku_site#231 makes whoami report it; this reads it from there.

## Fallbacks, deliberately

- **whoami doesn't carry the fields** → standalone GET, as before. Covers an older edge-router and any host not behind one (Capacitor, Storybook). This is what makes the deploy order free.
- **Both fields must be numbers**, and `maxContentLevel >= 1`. A body carrying a level without its ceiling would render a pill with zero segments — worse than refetching, because it looks like a working control that offers nothing.
- **Host supplied `userType`** → the whoami body read is skipped entirely. That prop exists for apps that *cannot* reach `/session/whoami` (conjure sits behind a path-prefixed shim where it 404s), so asking anyway would spend a request to learn nothing.

## Verification

Two new specs in `e2e/settings-prefetch.spec.ts`:

- **takes the content level off whoami** — stubs whoami with `maxContentLevel: 4` while the content-level stub serves `maxLevel: 3`, then asserts 4 pill segments and `content-level` request count `0`. The value can only have come from whoami.
- **falls back to the GET when whoami does not carry the level** — asserts the fallback fires and the pill still fills.

Full suite: **109 passed, 1 skipped** (the opt-in `RUN_PROD_PERF` spec), with the real `dev:api` stack up.