### PR TITLE
for automation boards, if a question has been answered i would pr…

### DIFF
--- a/e2e/plan-review.spec.ts
+++ b/e2e/plan-review.spec.ts
@@ -241,13 +241,45 @@ test.describe('plan review', () => {
     expect(notes).toContain('1. Should the reply append under Questions, or at the end of the doc?')
   })
 
-  test("a reviewer's own answer is not counted back as a question", async ({ page }) => {
+  test("a reviewer's own answer switches the badge to answered, not counted back as a question", async ({
+    page,
+    request
+  }) => {
     await card(page, 'Plan under review').getByRole('button', { name: 'Open notes' }).click()
     await page.locator('#notes-popout-reply').fill('Both answered.')
     await page.getByRole('button', { name: 'Add answer' }).click()
     await expect(page.locator('#notes-popout-reply')).toHaveValue('')
 
-    await expect(page.locator('.notes-popout__question-count')).toHaveText('2 open questions')
+    // The popout header goes quiet on "open" and reads "answered" instead —
+    // not silence, and not still nagging.
+    await expect(page.locator('.notes-popout__question-count')).toHaveText('Answered questions')
+    await expect(page.locator('.notes-popout__question-count')).toHaveClass(
+      /notes-popout__question-count--answered/
+    )
+    await page.locator('.notes-popout__close').click()
+
+    // Same tri-state on the card itself.
+    await expect(
+      card(page, 'Plan under review').locator('.task-app__item-questions')
+    ).toHaveText('Answered questions')
+    await expect(
+      card(page, 'Plan under review').locator('.task-app__item-questions')
+    ).toHaveClass(/task-app__item-questions--answered/)
+
+    // A replan rewrites notes wholesale with a fresh, un-replied Questions
+    // list — the badge has to flip straight back to "open", not stay stuck on
+    // "answered" from the reply that no longer applies to anything.
+    const patched = await request.patch(`${API}/${boardId}-a`, {
+      data: {
+        boardId,
+        notes: `## Questions\n\n1. Is the new plan good?\n2. Anything else to settle?\n`
+      }
+    })
+    expect(patched.ok()).toBe(true)
+    await openBoard(page, boardId)
+    await expect(
+      card(page, 'Plan under review').locator('.task-app__item-questions')
+    ).toHaveText('2 open questions')
   })
 
   test('Escape backs out of the editor first, then the dialog', async ({ page }) => {

--- a/src/components/NotesPopout.tsx
+++ b/src/components/NotesPopout.tsx
@@ -29,6 +29,7 @@ import {
   appendAnswerToNotes,
   openQuestionCount,
   parsePlanNotes,
+  questionsAnswered,
   type PlanSection
 } from '../domain/planNotes'
 import { PlanMarkdown } from './PlanMarkdown'
@@ -60,6 +61,7 @@ export function NotesPopout({
 
   const sections = useMemo(() => parsePlanNotes(notes), [notes])
   const questionCount = useMemo(() => openQuestionCount(sections), [sections])
+  const answered = useMemo(() => questionsAnswered(sections), [sections])
   const panelRef = useRef<HTMLDivElement>(null)
 
   // Keep focus inside the dialog: on open, and again whenever the mode flips.
@@ -135,11 +137,18 @@ export function NotesPopout({
         <header className="notes-popout__header">
           <div className="notes-popout__heading">
             <h2 className="notes-popout__title">{title}</h2>
-            {questionCount > 0 && !editing && (
-              <span className="notes-popout__question-count">
-                {questionCount} open {questionCount === 1 ? 'question' : 'questions'}
-              </span>
-            )}
+            {!editing &&
+              (questionCount > 0 ? (
+                <span className="notes-popout__question-count">
+                  {questionCount} open {questionCount === 1 ? 'question' : 'questions'}
+                </span>
+              ) : (
+                answered && (
+                  <span className="notes-popout__question-count notes-popout__question-count--answered">
+                    Answered questions
+                  </span>
+                )
+              ))}
           </div>
           <button className="notes-popout__close" onClick={onClose} aria-label="Close notes">
             ×

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -6,7 +6,7 @@ import React, { useMemo, useRef, useState } from 'react'
 import type { Task } from '../domain/types'
 import { formatAge } from '../utils/formatters'
 import { formatTagsForDisplay } from '../domain/utils/tags'
-import { openQuestionCount, parsePlanNotes } from '../domain/planNotes'
+import { openQuestionCount, parsePlanNotes, questionsAnswered } from '../domain/planNotes'
 import { NotesPopout } from './NotesPopout'
 import { TagIcon } from '@wolffm/task-ui-components'
 
@@ -60,7 +60,14 @@ export function TaskItem({
   // a reviewer can see which of a lane's tasks need them without opening each
   // one — Questions is the only section that asks anything, so it's the only
   // thing worth counting here.
-  const openQuestions = useMemo(() => openQuestionCount(parsePlanNotes(task.notes)), [task.notes])
+  const planSections = useMemo(() => parsePlanNotes(task.notes), [task.notes])
+  const openQuestions = useMemo(() => openQuestionCount(planSections), [planSections])
+  // Once a reply has landed and no new questions replaced it, the row goes
+  // quiet on "open" and says so was answered instead — distinct from just
+  // having no badge, so a reviewer can tell "never asked" apart from
+  // "asked and answered". A replan that rewrites Questions with a fresh,
+  // un-replied list flips this back to `openQuestions > 0` automatically.
+  const answered = useMemo(() => questionsAnswered(planSections), [planSections])
 
   // The popout portals to the app root: out of this card (which clips and
   // drags), but not out of `.task-app-container`, which is where every theme
@@ -201,18 +208,26 @@ export function TaskItem({
           </div>
         </div>
 
-        {openQuestions > 0 && (
+        {openQuestions > 0 ? (
           <div className="task-app__item-questions">
             <span className="task-app__item-text" onMouseDown={suppressDragForText}>
               {openQuestions} open {openQuestions === 1 ? 'question' : 'questions'}
             </span>
           </div>
+        ) : (
+          answered && (
+            <div className="task-app__item-questions task-app__item-questions--answered">
+              <span className="task-app__item-text" onMouseDown={suppressDragForText}>
+                Answered questions
+              </span>
+            </div>
+          )
         )}
       </div>
       <div className="task-app__item-actions">
         {onSetNotes && showNotesButton && (
           <button
-            className={`task-app__action-btn task-app__notes-toggle ${hasNotes ? 'has-notes' : ''} ${openQuestions > 0 ? 'has-questions' : ''}`}
+            className={`task-app__action-btn task-app__notes-toggle ${hasNotes ? 'has-notes' : ''} ${openQuestions > 0 ? 'has-questions' : ''} ${openQuestions === 0 && answered ? 'has-answered-questions' : ''}`}
             onClick={() => setNotesOpen(true)}
             title={hasNotes ? 'Open notes' : 'Add notes'}
             aria-label={hasNotes ? 'Open notes' : 'Add notes'}

--- a/src/domain/planNotes.ts
+++ b/src/domain/planNotes.ts
@@ -105,16 +105,45 @@ export function questionsSection(sections: PlanSection[]): PlanSection | undefin
 
 /**
  * Group a section body into list items, folding each item's wrapped
- * continuation lines back into it. Text before the first marker is its own
- * item, so a prose-only section still counts as something.
+ * continuation lines back into it, and pull out a trailing reply paragraph if
+ * one follows the list after a blank line.
+ *
+ * `appendAnswerToNotes` always inserts a human's reply as its own
+ * blank-line-separated paragraph after the question list — never as another
+ * list item, never glued onto one with a wrapped-line continuation. So a
+ * non-list line immediately following an item (no blank line between) is a
+ * wrapped continuation of that item, same as before; but once a blank line has
+ * been seen after the list, a non-list line starts (or continues) the reply
+ * block instead of merging into the last item. Text before the first marker is
+ * still its own item, so a prose-only section counts as something.
  */
-function listItems(body: string): string[] {
+function parseQuestionsBody(body: string): { items: string[]; reply: string | undefined } {
   const items: string[] = []
+  let reply: string[] | undefined
+  let blankSinceLastItem = false
+
   for (const line of body.split('\n')) {
-    if (LIST_ITEM.test(line) || !items.length) items.push(line.trim())
-    else if (line.trim()) items[items.length - 1] += ` ${line.trim()}`
+    const trimmed = line.trim()
+    if (!trimmed) {
+      if (items.length) blankSinceLastItem = true
+      continue
+    }
+    if (LIST_ITEM.test(line)) {
+      items.push(trimmed)
+      blankSinceLastItem = false
+      reply = undefined
+      continue
+    }
+    if (items.length && blankSinceLastItem) {
+      ;(reply ??= []).push(trimmed)
+    } else if (items.length) {
+      items[items.length - 1] += ` ${trimmed}`
+    } else {
+      items.push(trimmed)
+    }
   }
-  return items.filter(Boolean)
+
+  return { items: items.filter(Boolean), reply: reply?.join(' ') }
 }
 
 /**
@@ -132,6 +161,10 @@ function listItems(body: string): string[] {
  * section has a `?` at all, the questions are phrased imperatively ("Confirm the
  * repo.") and every item counts. The "No open questions." sentinel is 0.
  *
+ * Once a reply paragraph trails the list (see `parseQuestionsBody`), the
+ * question(s) it answers are done — the count goes to 0 rather than nagging
+ * forever. `questionsAnswered` is the signal for what to show instead.
+ *
  * It cannot be exact — free text is the point — but it errs toward the count
  * going quiet once you have answered rather than nagging forever.
  */
@@ -142,9 +175,28 @@ export function openQuestionCount(sections: PlanSection[]): number {
   const body = section.body.trim()
   if (!body || NO_QUESTIONS.test(stripSentinelMarkup(body))) return 0
 
-  const items = listItems(body)
-  if (!body.includes('?')) return items.length
+  const { items, reply } = parseQuestionsBody(body)
+  if (reply !== undefined) return 0
+
+  if (!items.some(item => item.includes('?'))) return items.length
   return items.filter(item => item.includes('?')).length
+}
+
+/**
+ * True once a human has replied to a Questions section that actually asked
+ * something — the signal behind the "Answered questions" badge, which takes
+ * over from "N open questions" the moment a reply lands and reverts the moment
+ * a replan rewrites the section with a fresh, un-replied list.
+ */
+export function questionsAnswered(sections: PlanSection[]): boolean {
+  const section = questionsSection(sections)
+  if (!section) return false
+
+  const body = section.body.trim()
+  if (!body || NO_QUESTIONS.test(stripSentinelMarkup(body))) return false
+
+  const { items, reply } = parseQuestionsBody(body)
+  return items.length > 0 && reply !== undefined
 }
 
 /**

--- a/src/styles/notes-popout.css
+++ b/src/styles/notes-popout.css
@@ -84,6 +84,13 @@
   white-space: nowrap;
 }
 
+/* Answered is a different state from "still open" — the success family keeps
+   it from reading as another thing left for the reviewer to do. */
+.notes-popout__question-count--answered {
+  background-color: var(--color-success-bg);
+  color: var(--color-on-success-bg);
+}
+
 .notes-popout__close {
   flex-shrink: 0;
   width: 32px;

--- a/src/styles/task-items.css
+++ b/src/styles/task-items.css
@@ -179,6 +179,16 @@
   opacity: 1;
 }
 
+/* A question that's been answered no longer needs the warning tint — that's
+   reserved for "still waiting on you" — but it stays visually distinct from a
+   plain notes toggle so a reviewer can tell "answered" apart from "nothing to
+   answer" at a glance. */
+.task-app__notes-toggle.has-answered-questions {
+  background-color: var(--color-success-bg);
+  color: var(--color-on-success-bg);
+  opacity: 1;
+}
+
 .task-app__item-questions {
   margin-top: var(--hdk-space-xs);
   align-self: flex-start;
@@ -189,6 +199,11 @@
   font-size: var(--hdk-text-xs);
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
+}
+
+.task-app__item-questions--answered {
+  background-color: var(--color-success-bg);
+  color: var(--color-on-success-bg);
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
Opened by hadoku-task-automation for task `MSNX1UO0OH751W6NGS6FGTEB7B`.

**Task as filed:** for automation boards, if a question has been answered i would prefer if the task row didn't show '1 open questions' anymore, ideally it's a different color and is written 'answered questions'. obiously if theres a replan and there are new open questions then it should go back to open questions

Nobody has reviewed this. **Auto-merge is armed**: GitHub lands it when the 3 required check(s) on `main` go green, and leaves it open if any of them go red. Close it or disable auto-merge if the diff reads wrong.

### Preflight
- diff_non_empty: 6 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/msnx1uo0oh75
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed 2638791b → taskauto/msnx1uo0oh75