### PR TITLE
slight alignment issue with the notes emoji. it doesn't appear to…

### DIFF
--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -127,6 +127,18 @@
   height: 16px;
 }
 
+/* The notes icon is a themes `Icon` (`note` / notebook-pen), sized `1em` by
+   default like every other `hdk-icon` consumer. Its glyph is symmetric within
+   its own viewBox, but `.task-app__action-btn`'s centering formula
+   (padding-top: min-height/2 - 0.5em) anchors the box's *top* edge, so a
+   14px (1em) box reads ~1px high next to the complete/delete text glyphs.
+   Match the tag button's explicit 16px box above — the anchored top stays
+   put and the extra height shifts the visual center down to line up. */
+.task-app__notes-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
 /* Complete button */
 .task-app__action-btn.task-app__complete-btn {
   background: linear-gradient(180deg, var(--color-success) 0%, var(--color-success-dark) 100%);


### PR DESCRIPTION
Opened by hadoku-task-automation for task `MSS0SPGSLYBZW2D2QSKS5Y8SC2`.

**Task as filed:** slight alignment issue with the notes emoji. it doesn't appear to be perfectly vertically centered on the task row. might be the height of the emoji/icon itself or a css problem

Nobody has reviewed this. **Auto-merge is armed**: GitHub lands it when the 3 required check(s) on `main` go green, and leaves it open if any of them go red. Close it or disable auto-merge if the diff reads wrong.

### Preflight
- diff_non_empty: 1 file(s)
- blast_radius: within 20 files
- protected_paths: clean
- committed on taskauto/mss0spgslybz
- merged current origin/main
- NO TEST COMMAND — nothing verified this change
- pushed a47ac31f → taskauto/mss0spgslybz